### PR TITLE
Add a core domain initial digram and a glossary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ bld/
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
+# VS Code
+.vscode/
 
 # Visual Studio 2017 auto generated files
 Generated\ Files/

--- a/docs/diagrams/src/ddd/yiyo-2-core-domain-inital-digram.puml
+++ b/docs/diagrams/src/ddd/yiyo-2-core-domain-inital-digram.puml
@@ -1,0 +1,32 @@
+@startuml core-domain-initial
+skinparam packageStyle rectangle
+
+package Reflection {
+    package {
+        usecase Part
+        usecase "Year In" as YearIn
+        usecase "Year Out" as YearOut
+    }
+    usecase Event
+    usecase "World event" as WorldEvent
+    usecase "Personal event" as PersonalEvent
+    usecase Feeling
+    usecase Motto
+    usecase Source
+}
+
+Event <|-- WorldEvent : is-an <
+Event <|-- PersonalEvent : is-an <
+Feeling "1" *- "0..*" PersonalEvent : references >
+WorldEvent "1" *-- "0..*" Source : references <
+Part <|-- YearIn : is-a <
+Part <|-- YearOut : is-a <
+YearIn "1" *- "*" WorldEvent : has >
+YearIn "1" *-- "*" PersonalEvent : has >
+YearIn "1" *-- "*" Feeling : has >
+YearIn "1" *-- "1" Motto : has >
+YearOut "1" *-- "*" PersonalEvent : has >
+YearOut "1" *-- "*" Feeling : has >
+YearOut "1" *-- "1" Motto : has >
+
+@enduml

--- a/docs/domain/UbiquitousLanguage.md
+++ b/docs/domain/UbiquitousLanguage.md
@@ -1,0 +1,27 @@
+# Glossry for the Ubiquitous Language
+
+## Core domain - Reflection
+
+### Entities
+
+The entities in the core domain:
+
+- Event
+  - World event (outside of the circles)
+  - Personal event (outer circle)
+- Feeling (middle circle)
+- Motto (inner circle)
+- Source
+- Part
+  - Year In
+  - Year Out
+
+An event is either a World event or a Personal.
+A feeling may references Personal events.
+A World event may be referenced by a Source.
+There may be only one (or possible maximally two,
+I need to think about it) motto per part.
+The whole reflection is divided into two Parts:
+One for the year the ended (Year In) and
+one for the coming year (Year Out).
+Year out (obviously) has no world events.

--- a/docs/domain/UbiquitousLanguage.md
+++ b/docs/domain/UbiquitousLanguage.md
@@ -17,11 +17,11 @@ The entities in the core domain:
   - Year Out
 
 An event is either a World event or a Personal.
-A feeling may references Personal events.
+A feeling may reference Personal events.
 A World event may be referenced by a Source.
 There may be only one (or possible maximally two,
 I need to think about it) motto per part.
 The whole reflection is divided into two Parts:
-One for the year the ended (Year In) and
+One for the year that ended (Year In) and
 one for the coming year (Year Out).
 Year out (obviously) has no world events.


### PR DESCRIPTION
In this PR, we add a PlantUML digram for the core domain (at least a rough core domain model, with a couple of entities), and a Ubiquitous Language Glossary.
This is only a rough beginning, to help guide us at first without spending too long on it.