### PR TITLE
[YIYO-16] (feature): Setup CQRS queries for all entities

### DIFF
--- a/YearInYearOut.sln
+++ b/YearInYearOut.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YaronEfrat.Yiyo.Domain.Refl
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YaronEfrat.Yiyo.Application", "src\YaronEfrat.Yiyo.Application\YaronEfrat.Yiyo.Application.csproj", "{CC9590A8-F3D0-448E-A07E-41114ED80963}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YaronEfrat.Yiyo.Application.UnitTests", "tests\YaronEfrat.Yiyo.Application.UnitTests\YaronEfrat.Yiyo.Application.UnitTests.csproj", "{036AF25E-213F-4250-AA4B-AD86F591C2DB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,10 @@ Global
 		{CC9590A8-F3D0-448E-A07E-41114ED80963}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CC9590A8-F3D0-448E-A07E-41114ED80963}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CC9590A8-F3D0-448E-A07E-41114ED80963}.Release|Any CPU.Build.0 = Release|Any CPU
+		{036AF25E-213F-4250-AA4B-AD86F591C2DB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{036AF25E-213F-4250-AA4B-AD86F591C2DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{036AF25E-213F-4250-AA4B-AD86F591C2DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{036AF25E-213F-4250-AA4B-AD86F591C2DB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/YearInYearOut.sln
+++ b/YearInYearOut.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YaronEfrat.Yiyo.WebApi", "s
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YaronEfrat.Yiyo.Domain.Reflection", "src\Domain.Reflection\YaronEfrat.Yiyo.Domain.Reflection.csproj", "{2D2399A6-2AA5-4F8C-8E1D-348E2FB0FFFD}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YaronEfrat.Yiyo.Application", "src\YaronEfrat.Yiyo.Application\YaronEfrat.Yiyo.Application.csproj", "{CC9590A8-F3D0-448E-A07E-41114ED80963}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{2D2399A6-2AA5-4F8C-8E1D-348E2FB0FFFD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2D2399A6-2AA5-4F8C-8E1D-348E2FB0FFFD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2D2399A6-2AA5-4F8C-8E1D-348E2FB0FFFD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC9590A8-F3D0-448E-A07E-41114ED80963}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC9590A8-F3D0-448E-A07E-41114ED80963}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC9590A8-F3D0-448E-A07E-41114ED80963}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC9590A8-F3D0-448E-A07E-41114ED80963}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/YaronEfrat.Yiyo.Application/Interfaces/IApplicationDbContext.cs
+++ b/src/YaronEfrat.Yiyo.Application/Interfaces/IApplicationDbContext.cs
@@ -1,0 +1,29 @@
+﻿using System.Data;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+
+namespace YaronEfrat.Yiyo.Application.Interfaces;
+
+public interface IApplicationDbContext
+{
+    IDbConnection Connection { get; }
+
+    DatabaseFacade Database { get; }
+
+    DbSet<FeelingEntity> Feelings { get; }
+
+    bool HasChanges { get; }
+
+    DbSet<MottoEntity> Mottos { get; }
+
+    DbSet<PersonalEventEntity> PersonalEvents { get; }
+
+    DbSet<WorldEventEntity> WorldEvents { get; }
+
+    DbSet<YearInEntity> YearIns { get; }
+
+    DbSet<YearOutEntity> YearOuts { get; }
+
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/src/YaronEfrat.Yiyo.Application/Interfaces/IApplicationDbContext.cs
+++ b/src/YaronEfrat.Yiyo.Application/Interfaces/IApplicationDbContext.cs
@@ -3,6 +3,8 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
+using YaronEfrat.Yiyo.Application.Models;
+
 namespace YaronEfrat.Yiyo.Application.Interfaces;
 
 public interface IApplicationDbContext
@@ -18,6 +20,8 @@ public interface IApplicationDbContext
     DbSet<MottoEntity> Mottos { get; }
 
     DbSet<PersonalEventEntity> PersonalEvents { get; }
+
+    DbSet<SourceEntity> Sources { get; }
 
     DbSet<WorldEventEntity> WorldEvents { get; }
 

--- a/src/YaronEfrat.Yiyo.Application/Interfaces/IDbEntity.cs
+++ b/src/YaronEfrat.Yiyo.Application/Interfaces/IDbEntity.cs
@@ -1,6 +1,6 @@
 ﻿namespace YaronEfrat.Yiyo.Application.Interfaces;
 
-internal interface IDbEntity
+public interface IDbEntity
 {
     int ID { get; }
 }

--- a/src/YaronEfrat.Yiyo.Application/Interfaces/IDbEntity.cs
+++ b/src/YaronEfrat.Yiyo.Application/Interfaces/IDbEntity.cs
@@ -1,4 +1,5 @@
 ﻿namespace YaronEfrat.Yiyo.Application.Interfaces;
+
 internal interface IDbEntity
 {
     int ID { get; }

--- a/src/YaronEfrat.Yiyo.Application/Interfaces/IDbEntity.cs
+++ b/src/YaronEfrat.Yiyo.Application/Interfaces/IDbEntity.cs
@@ -1,0 +1,5 @@
+﻿namespace YaronEfrat.Yiyo.Application.Interfaces;
+internal interface IDbEntity
+{
+    int ID { get; }
+}

--- a/src/YaronEfrat.Yiyo.Application/Models/FeelingEntity.cs
+++ b/src/YaronEfrat.Yiyo.Application/Models/FeelingEntity.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+
+namespace YaronEfrat.Yiyo.Application.Models;
+
+public class FeelingEntity : IDbEntity
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int ID { get; set; }
+
+    public string Title { get; set; }
+
+    public string Description { get; set; }
+
+    public virtual ICollection<PersonalEventEntity> PersonalEvents { get; set; }
+}

--- a/src/YaronEfrat.Yiyo.Application/Models/MottoEntity.cs
+++ b/src/YaronEfrat.Yiyo.Application/Models/MottoEntity.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using YaronEfrat.Yiyo.Application.Interfaces;
+
+namespace YaronEfrat.Yiyo.Application.Models;
+
+public class MottoEntity : IDbEntity
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int ID { get; set; }
+
+    public string Content { get; set; }
+}

--- a/src/YaronEfrat.Yiyo.Application/Models/PersonalEventEntity.cs
+++ b/src/YaronEfrat.Yiyo.Application/Models/PersonalEventEntity.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using YaronEfrat.Yiyo.Application.Interfaces;
+
+namespace YaronEfrat.Yiyo.Application.Models;
+
+public class PersonalEventEntity : IDbEntity
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int ID { get; set; }
+
+    public string Title { get; set; }
+}

--- a/src/YaronEfrat.Yiyo.Application/Models/SourceEntity.cs
+++ b/src/YaronEfrat.Yiyo.Application/Models/SourceEntity.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+
+namespace YaronEfrat.Yiyo.Application.Models;
+
+public class SourceEntity : IDbEntity
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int ID { get; set; }
+
+    public Uri Url { get; set; }
+}

--- a/src/YaronEfrat.Yiyo.Application/Models/WorldEventEntity.cs
+++ b/src/YaronEfrat.Yiyo.Application/Models/WorldEventEntity.cs
@@ -1,0 +1,14 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using YaronEfrat.Yiyo.Application.Interfaces;
+
+namespace YaronEfrat.Yiyo.Application.Models;
+
+public class WorldEventEntity : IDbEntity
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int ID { get; set; }
+
+    public ICollection<SourceEntity> Sources { get; set; }
+
+    public string Title { get; set; }
+}

--- a/src/YaronEfrat.Yiyo.Application/Models/YearInEntity.cs
+++ b/src/YaronEfrat.Yiyo.Application/Models/YearInEntity.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+
+namespace YaronEfrat.Yiyo.Application.Models;
+
+public class YearInEntity : IDbEntity
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int ID { get; set; }
+
+    public ICollection<FeelingEntity> Feelings { get; set; }
+
+    public MottoEntity Motto { get; set; }
+
+    public ICollection<PersonalEventEntity> PersonalEvents { get; set; }
+
+    public ICollection<WorldEventEntity> WorldEvents { get; set; }
+}

--- a/src/YaronEfrat.Yiyo.Application/Models/YearOutEntity.cs
+++ b/src/YaronEfrat.Yiyo.Application/Models/YearOutEntity.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+
+namespace YaronEfrat.Yiyo.Application.Models;
+
+public class YearOutEntity : IDbEntity
+{
+    [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+    public int ID { get; set; }
+
+    public ICollection<FeelingEntity> Feelings { get; set; }
+
+    public MottoEntity Motto { get; set; }
+
+    public ICollection<PersonalEventEntity> PersonalEvents { get; set; }
+}

--- a/src/YaronEfrat.Yiyo.Application/Queries/GetFeelingQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/GetFeelingQuery.cs
@@ -1,0 +1,26 @@
+﻿using MediatR;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+using YaronEfrat.Yiyo.Application.Models;
+
+namespace YaronEfrat.Yiyo.Application.Queries;
+
+public class GetFeelingQuery : IRequest<FeelingEntity>
+{
+    public int Id { get; init; }
+}
+
+public class GetFeelingQueryHandler : IRequestHandler<GetFeelingQuery, FeelingEntity>
+{
+    private readonly IApplicationDbContext _context;
+
+    public GetFeelingQueryHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<FeelingEntity> Handle(GetFeelingQuery request, CancellationToken cancellationToken = default)
+    {
+        return _context.Feelings.SingleOrDefault(feel => feel.ID.Equals(request.Id));
+    }
+}

--- a/src/YaronEfrat.Yiyo.Application/Queries/GetFeelingQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/GetFeelingQuery.cs
@@ -8,6 +8,8 @@ namespace YaronEfrat.Yiyo.Application.Queries;
 public class GetFeelingQuery : IRequest<FeelingEntity>
 {
     public int Id { get; init; }
+
+    public string Title { get; init; }
 }
 
 public class GetFeelingQueryHandler : IRequestHandler<GetFeelingQuery, FeelingEntity>
@@ -21,6 +23,13 @@ public class GetFeelingQueryHandler : IRequestHandler<GetFeelingQuery, FeelingEn
 
     public async Task<FeelingEntity> Handle(GetFeelingQuery request, CancellationToken cancellationToken = default)
     {
-        return _context.Feelings.SingleOrDefault(feel => feel.ID.Equals(request.Id));
+        if (request.Id > 0)
+        {
+            return _context.Feelings.SingleOrDefault(feel => feel.ID.Equals(request.Id))!;
+        }
+
+        return (!string.IsNullOrWhiteSpace(request.Title)
+            ? _context.Feelings.SingleOrDefault(feel => feel.Title.Equals(request.Title))
+            : null)!;
     }
 }

--- a/src/YaronEfrat.Yiyo.Application/Queries/GetMottoQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/GetMottoQuery.cs
@@ -1,0 +1,26 @@
+﻿using MediatR;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+using YaronEfrat.Yiyo.Application.Models;
+
+namespace YaronEfrat.Yiyo.Application.Queries;
+
+public class GetMottoQuery : IRequest<MottoEntity>
+{
+    public int Id { get; init; }
+}
+
+public class GetMottoQueryHandler : IRequestHandler<GetMottoQuery, MottoEntity>
+{
+    private readonly IApplicationDbContext _context;
+
+    public GetMottoQueryHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<MottoEntity> Handle(GetMottoQuery request, CancellationToken cancellationToken = default)
+    {
+        return _context.Mottos.SingleOrDefault(motto => motto.ID.Equals(request.Id))!;
+    }
+}

--- a/src/YaronEfrat.Yiyo.Application/Queries/GetPersonalEventQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/GetPersonalEventQuery.cs
@@ -1,0 +1,35 @@
+﻿using MediatR;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+using YaronEfrat.Yiyo.Application.Models;
+
+namespace YaronEfrat.Yiyo.Application.Queries;
+
+public class GetPersonalEventQuery : IRequest<PersonalEventEntity>
+{
+    public int Id { get; init; }
+
+    public string Title { get; init; }
+}
+
+public class GetPersonalEventQueryHandler : IRequestHandler<GetPersonalEventQuery, PersonalEventEntity>
+{
+    private readonly IApplicationDbContext _context;
+
+    public GetPersonalEventQueryHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<PersonalEventEntity> Handle(GetPersonalEventQuery request, CancellationToken cancellationToken = default)
+    {
+        if (request.Id > 0)
+        {
+            return _context.PersonalEvents.SingleOrDefault(pe => pe.ID.Equals(request.Id))!;
+        }
+
+        return (!string.IsNullOrWhiteSpace(request.Title)
+            ? _context.PersonalEvents.SingleOrDefault(pe => pe.Title.Equals(request.Title))
+            : null)!;
+    }
+}

--- a/src/YaronEfrat.Yiyo.Application/Queries/GetSourceQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/GetSourceQuery.cs
@@ -1,0 +1,26 @@
+﻿using MediatR;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+using YaronEfrat.Yiyo.Application.Models;
+
+namespace YaronEfrat.Yiyo.Application.Queries;
+
+public class GetSourceQuery : IRequest<SourceEntity>
+{
+    public int Id { get; init; }
+}
+
+public class GetSourceQueryHandler : IRequestHandler<GetSourceQuery, SourceEntity>
+{
+    private readonly IApplicationDbContext _context;
+
+    public GetSourceQueryHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<SourceEntity> Handle(GetSourceQuery request, CancellationToken cancellationToken = default)
+    {
+        return _context.Sources.SingleOrDefault(source => source.ID.Equals(request.Id))!;
+    }
+}

--- a/src/YaronEfrat.Yiyo.Application/Queries/GetWorldEventQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/GetWorldEventQuery.cs
@@ -1,0 +1,35 @@
+﻿using MediatR;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+using YaronEfrat.Yiyo.Application.Models;
+
+namespace YaronEfrat.Yiyo.Application.Queries;
+
+public class GetWorldEventQuery : IRequest<WorldEventEntity>
+{
+    public int Id { get; init; }
+
+    public string Title { get; init; }
+}
+
+public class GetWorldEventQueryHandler : IRequestHandler<GetWorldEventQuery, WorldEventEntity>
+{
+    private readonly IApplicationDbContext _context;
+
+    public GetWorldEventQueryHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<WorldEventEntity> Handle(GetWorldEventQuery request, CancellationToken cancellationToken = default)
+    {
+        if (request.Id > 0)
+        {
+            return _context.WorldEvents.SingleOrDefault(pe => pe.ID.Equals(request.Id))!;
+        }
+
+        return (!string.IsNullOrWhiteSpace(request.Title)
+            ? _context.WorldEvents.SingleOrDefault(pe => pe.Title.Equals(request.Title))
+            : null)!;
+    }
+}

--- a/src/YaronEfrat.Yiyo.Application/Queries/GetYearInQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/GetYearInQuery.cs
@@ -1,0 +1,26 @@
+﻿using MediatR;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+using YaronEfrat.Yiyo.Application.Models;
+
+namespace YaronEfrat.Yiyo.Application.Queries;
+
+public class GetYearInQuery : IRequest<YearInEntity>
+{
+    public int Id { get; init; }
+}
+
+public class GetYearInQueryHandler : IRequestHandler<GetYearInQuery, YearInEntity>
+{
+    private readonly IApplicationDbContext _context;
+
+    public GetYearInQueryHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<YearInEntity> Handle(GetYearInQuery request, CancellationToken cancellationToken = default)
+    {
+        return _context.YearIns.SingleOrDefault(yearIn => yearIn.ID.Equals(request.Id))!;
+    }
+}

--- a/src/YaronEfrat.Yiyo.Application/Queries/GetYearOutQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/GetYearOutQuery.cs
@@ -1,0 +1,26 @@
+﻿using MediatR;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+using YaronEfrat.Yiyo.Application.Models;
+
+namespace YaronEfrat.Yiyo.Application.Queries;
+
+public class GetYearOutQuery : IRequest<YearOutEntity>
+{
+    public int Id { get; init; }
+}
+
+public class GetYearOutQueryHandler : IRequestHandler<GetYearOutQuery, YearOutEntity>
+{
+    private readonly IApplicationDbContext _context;
+
+    public GetYearOutQueryHandler(IApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<YearOutEntity> Handle(GetYearOutQuery request, CancellationToken cancellationToken = default)
+    {
+        return _context.YearOuts.SingleOrDefault(yearOut => yearOut.ID.Equals(request.Id))!;
+    }
+}

--- a/src/YaronEfrat.Yiyo.Application/YaronEfrat.Yiyo.Application.csproj
+++ b/src/YaronEfrat.Yiyo.Application/YaronEfrat.Yiyo.Application.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MediatR" Version="12.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/YaronEfrat.Yiyo.Application/YaronEfrat.Yiyo.Application.csproj
+++ b/src/YaronEfrat.Yiyo.Application/YaronEfrat.Yiyo.Application.csproj
@@ -8,6 +8,11 @@
 
   <ItemGroup>
     <PackageReference Include="MediatR" Version="12.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Domain.Reflection\YaronEfrat.Yiyo.Domain.Reflection.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/DbEntitiesTestCases.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/DbEntitiesTestCases.cs
@@ -10,6 +10,9 @@ internal class DbEntitiesTestCases
     public const string MovedToBerlin = "Moved to Berlin";
     public const string SawTheMoon = "Saw the moon";
 
+    public static readonly Uri Source1 = new("http://source1.net");
+    public static readonly Uri Source2 = new("http://source2.net");
+
     internal static readonly IReadOnlyList<FeelingEntity> Feelings = new List<FeelingEntity>()
     {
         new()
@@ -49,6 +52,20 @@ internal class DbEntitiesTestCases
         {
             ID = 2,
             Title = SawTheMoon,
+        },
+    };
+
+    internal static readonly IReadOnlyList<SourceEntity> Sources = new List<SourceEntity>()
+    {
+        new()
+        {
+            ID = 1,
+            Url  = Source1,
+        },
+        new()
+        {
+            ID = 2,
+            Url  = Source2,
         },
     };
 }

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/DbEntitiesTestCases.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/DbEntitiesTestCases.cs
@@ -1,7 +1,7 @@
 ﻿using YaronEfrat.Yiyo.Application.Models;
 
 namespace YaronEfrat.Yiyo.Application.UnitTests.Queries;
-internal class FeelingTestCases
+internal class DbEntitiesTestCases
 {
     internal static readonly IReadOnlyList<FeelingEntity> Feelings = new List<FeelingEntity>()
     {
@@ -14,6 +14,20 @@ internal class FeelingTestCases
         {
             ID = 2,
             Title = "Happy",
+        },
+    };
+
+    internal static readonly IReadOnlyList<MottoEntity> Mottos = new List<MottoEntity>()
+    {
+        new()
+        {
+            ID = 1,
+            Content  = "I am a motto",
+        },
+        new()
+        {
+            ID = 2,
+            Content = "Inspirational quote",
         },
     };
 }

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/DbEntitiesTestCases.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/DbEntitiesTestCases.cs
@@ -3,17 +3,24 @@
 namespace YaronEfrat.Yiyo.Application.UnitTests.Queries;
 internal class DbEntitiesTestCases
 {
+    public const string Sad = "Sad";
+    public const string Happy = "Happy";
+    public const string IAmAMotto = "I am a motto";
+    public const string InspirationalQuote = "Inspirational quote";
+    public const string MovedToBerlin = "Moved to Berlin";
+    public const string SawTheMoon = "Saw the moon";
+
     internal static readonly IReadOnlyList<FeelingEntity> Feelings = new List<FeelingEntity>()
     {
         new()
         {
             ID = 1,
-            Title = "Sad",
+            Title = Sad,
         },
         new()
         {
             ID = 2,
-            Title = "Happy",
+            Title = Happy,
         },
     };
 
@@ -22,12 +29,26 @@ internal class DbEntitiesTestCases
         new()
         {
             ID = 1,
-            Content  = "I am a motto",
+            Content  = IAmAMotto,
         },
         new()
         {
             ID = 2,
-            Content = "Inspirational quote",
+            Content = InspirationalQuote,
+        },
+    };
+
+    internal static readonly IReadOnlyList<PersonalEventEntity> PersonalEvents = new List<PersonalEventEntity>()
+    {
+        new()
+        {
+            ID = 1,
+            Title = MovedToBerlin,
+        },
+        new()
+        {
+            ID = 2,
+            Title = SawTheMoon,
         },
     };
 }

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/DbEntitiesTestCases.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/DbEntitiesTestCases.cs
@@ -15,7 +15,7 @@ internal class DbEntitiesTestCases
     public static readonly Uri Source1 = new("http://source1.net");
     public static readonly Uri Source2 = new("http://source2.net");
 
-    internal static readonly IReadOnlyList<FeelingEntity> Feelings = new List<FeelingEntity>()
+    internal static readonly IReadOnlyList<FeelingEntity> Feelings = new List<FeelingEntity>
     {
         new()
         {
@@ -29,7 +29,7 @@ internal class DbEntitiesTestCases
         },
     };
 
-    internal static readonly IReadOnlyList<MottoEntity> Mottos = new List<MottoEntity>()
+    internal static readonly IReadOnlyList<MottoEntity> Mottos = new List<MottoEntity>
     {
         new()
         {
@@ -43,7 +43,7 @@ internal class DbEntitiesTestCases
         },
     };
 
-    internal static readonly IReadOnlyList<PersonalEventEntity> PersonalEvents = new List<PersonalEventEntity>()
+    internal static readonly IReadOnlyList<PersonalEventEntity> PersonalEvents = new List<PersonalEventEntity>
     {
         new()
         {
@@ -57,7 +57,7 @@ internal class DbEntitiesTestCases
         },
     };
 
-    internal static readonly IReadOnlyList<SourceEntity> Sources = new List<SourceEntity>()
+    internal static readonly IReadOnlyList<SourceEntity> Sources = new List<SourceEntity>
     {
         new()
         {
@@ -71,7 +71,7 @@ internal class DbEntitiesTestCases
         },
     };
 
-    internal static readonly IReadOnlyList<WorldEventEntity> WorldEvents = new List<WorldEventEntity>()
+    internal static readonly IReadOnlyList<WorldEventEntity> WorldEvents = new List<WorldEventEntity>
     {
         new()
         {
@@ -82,6 +82,18 @@ internal class DbEntitiesTestCases
         {
             ID = 2,
             Title = War,
+        },
+    };
+
+    internal static readonly IReadOnlyList<YearInEntity> YearIns = new List<YearInEntity>
+    {
+        new()
+        {
+            ID = 1,
+        },
+        new()
+        {
+            ID = 2,
         },
     };
 }

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/DbEntitiesTestCases.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/DbEntitiesTestCases.cs
@@ -96,4 +96,16 @@ internal class DbEntitiesTestCases
             ID = 2,
         },
     };
+
+    internal static readonly IReadOnlyList<YearOutEntity> YearOuts = new List<YearOutEntity>
+    {
+        new()
+        {
+            ID = 1,
+        },
+        new()
+        {
+            ID = 2,
+        },
+    };
 }

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/DbEntitiesTestCases.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/DbEntitiesTestCases.cs
@@ -9,6 +9,8 @@ internal class DbEntitiesTestCases
     public const string InspirationalQuote = "Inspirational quote";
     public const string MovedToBerlin = "Moved to Berlin";
     public const string SawTheMoon = "Saw the moon";
+    public const string Corona = "Corona";
+    public const string War = "War";
 
     public static readonly Uri Source1 = new("http://source1.net");
     public static readonly Uri Source2 = new("http://source2.net");
@@ -66,6 +68,20 @@ internal class DbEntitiesTestCases
         {
             ID = 2,
             Url  = Source2,
+        },
+    };
+
+    internal static readonly IReadOnlyList<WorldEventEntity> WorldEvents = new List<WorldEventEntity>()
+    {
+        new()
+        {
+            ID = 1,
+            Title = Corona,
+        },
+        new()
+        {
+            ID = 2,
+            Title = War,
         },
     };
 }

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/FeelingTestCases.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/FeelingTestCases.cs
@@ -1,0 +1,19 @@
+﻿using YaronEfrat.Yiyo.Application.Models;
+
+namespace YaronEfrat.Yiyo.Application.UnitTests.Queries;
+internal class FeelingTestCases
+{
+    internal static readonly IReadOnlyList<FeelingEntity> Feelings = new List<FeelingEntity>()
+    {
+        new()
+        {
+            ID = 1,
+            Title = "Sad",
+        },
+        new()
+        {
+            ID = 2,
+            Title = "Happy",
+        },
+    };
+}

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetFeelingQueryHandlerTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetFeelingQueryHandlerTests.cs
@@ -23,21 +23,10 @@ internal class GetFeelingQueryHandlerTests
     {
         _dbContextMock = new Mock<IApplicationDbContext>();
 
-        Mock<DbSet<FeelingEntity>> dbSetMock = DbSetMock();
+        Mock<DbSet<FeelingEntity>> dbSetMock = TestFixtures.DbSetMock(DbEntitiesTestCases.Feelings);
         _dbContextMock.Setup(mock => mock.Feelings)
             .Returns(dbSetMock.Object);
         _getFeelingQueryHandler = new GetFeelingQueryHandler(_dbContextMock.Object);
-    }
-
-    private static Mock<DbSet<FeelingEntity>> DbSetMock()
-    {
-        IQueryable<FeelingEntity> queryable = FeelingTestCases.Feelings.AsQueryable();
-        Mock<DbSet<FeelingEntity>> dbSetMock = new();
-        dbSetMock.As<IQueryable<FeelingEntity>>().Setup(m => m.Provider).Returns(queryable.Provider);
-        dbSetMock.As<IQueryable<FeelingEntity>>().Setup(m => m.Expression).Returns(queryable.Expression);
-        dbSetMock.As<IQueryable<FeelingEntity>>().Setup(m => m.ElementType).Returns(queryable.ElementType);
-        dbSetMock.As<IQueryable<FeelingEntity>>().Setup(m => m.GetEnumerator()).Returns(() => queryable.GetEnumerator());
-        return dbSetMock;
     }
 
     [TestCase(1)]

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetFeelingQueryHandlerTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetFeelingQueryHandlerTests.cs
@@ -40,8 +40,8 @@ internal class GetFeelingQueryHandlerTests
         feeling.ID.Should().Be(id);
     }
 
-    [TestCase("Happy")]
-    [TestCase("Sad")]
+    [TestCase(DbEntitiesTestCases.Happy)]
+    [TestCase(DbEntitiesTestCases.Sad)]
     public async Task Should_ReturnCorrectFeeling_When_SearchingForExistingTitle(string title)
     {
         // Act

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetFeelingQueryHandlerTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetFeelingQueryHandlerTests.cs
@@ -1,0 +1,59 @@
+﻿using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using NUnit.Framework;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+using YaronEfrat.Yiyo.Application.Models;
+using YaronEfrat.Yiyo.Application.Queries;
+
+namespace YaronEfrat.Yiyo.Application.UnitTests.Queries;
+
+internal class GetFeelingQueryHandlerTests
+{
+    private Mock<IApplicationDbContext> _dbContextMock;
+
+    private GetFeelingQueryHandler _getFeelingQueryHandler;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _dbContextMock = new Mock<IApplicationDbContext>();
+
+        var queryable =  FeelingTestCases.Feelings.AsQueryable();
+        var dbSetMock = new Mock<DbSet<FeelingEntity>>();
+        dbSetMock.As<IQueryable<FeelingEntity>>().Setup(m => m.Provider).Returns(queryable.Provider);
+        dbSetMock.As<IQueryable<FeelingEntity>>().Setup(m => m.Expression).Returns(queryable.Expression);
+        dbSetMock.As<IQueryable<FeelingEntity>>().Setup(m => m.ElementType).Returns(queryable.ElementType);
+        dbSetMock.As<IQueryable<FeelingEntity>>().Setup(m => m.GetEnumerator()).Returns(() => queryable.GetEnumerator());
+        _dbContextMock.Setup(mock => mock.Feelings)
+            .Returns(dbSetMock.Object);
+        _getFeelingQueryHandler = new GetFeelingQueryHandler(_dbContextMock.Object);
+    }
+
+    [TestCase(1)]
+    [TestCase(2)]
+    public async Task Should_ReturnCorrectFeeling_When_SearchingForExistingId(int id)
+    {
+        // Act
+        FeelingEntity feeling = await _getFeelingQueryHandler.Handle(new GetFeelingQuery {Id = id});
+
+        // Assert
+        feeling.ID.Should().Be(id);
+    }
+
+    [TestCase(-1)]
+    [TestCase(0)]
+    [TestCase(100000)]
+    public async Task Should_ReturnNull_When_SearchingForNonExistantId(int id)
+    {
+        // Act
+        FeelingEntity feeling = await _getFeelingQueryHandler.Handle(new GetFeelingQuery { Id = id });
+
+        // Assert
+        feeling.Should().BeNull();
+    }
+}

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetMottoQueryHandlerTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetMottoQueryHandlerTests.cs
@@ -1,0 +1,54 @@
+﻿using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using NUnit.Framework;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+using YaronEfrat.Yiyo.Application.Models;
+using YaronEfrat.Yiyo.Application.Queries;
+
+namespace YaronEfrat.Yiyo.Application.UnitTests.Queries;
+
+internal class GetMottoQueryHandlerTests
+{
+    private Mock<IApplicationDbContext> _dbContextMock;
+
+    private GetMottoQueryHandler _getMottoQueryHandler;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _dbContextMock = new Mock<IApplicationDbContext>();
+
+        Mock<DbSet<MottoEntity>> dbSetMock = TestFixtures.DbSetMock(DbEntitiesTestCases.Mottos);
+        _dbContextMock.Setup(mock => mock.Mottos)
+            .Returns(dbSetMock.Object);
+        _getMottoQueryHandler = new GetMottoQueryHandler(_dbContextMock.Object);
+    }
+
+    [TestCase(1)]
+    [TestCase(2)]
+    public async Task Should_ReturnCorrectFeeling_When_SearchingForExistingId(int id)
+    {
+        // Act
+        MottoEntity feeling = await _getMottoQueryHandler.Handle(new GetMottoQuery {Id = id});
+
+        // Assert
+        feeling.ID.Should().Be(id);
+    }
+
+    [TestCase(-1)]
+    [TestCase(0)]
+    [TestCase(100000)]
+    public async Task Should_ReturnNull_When_SearchingForNonExistantId(int id)
+    {
+        // Act
+        MottoEntity feeling = await _getMottoQueryHandler.Handle(new GetMottoQuery { Id = id });
+
+        // Assert
+        feeling.Should().BeNull();
+    }
+}

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetPersonalEventQueryHandlerTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetPersonalEventQueryHandlerTests.cs
@@ -1,0 +1,76 @@
+﻿using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using NUnit.Framework;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+using YaronEfrat.Yiyo.Application.Models;
+using YaronEfrat.Yiyo.Application.Queries;
+
+namespace YaronEfrat.Yiyo.Application.UnitTests.Queries;
+
+internal class GetPersonalEventQueryHandlerTests
+{
+    private Mock<IApplicationDbContext> _dbContextMock;
+
+    private GetPersonalEventQueryHandler _getPersonalEventQueryHandler;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _dbContextMock = new Mock<IApplicationDbContext>();
+
+        Mock<DbSet<PersonalEventEntity>> dbSetMock = TestFixtures.DbSetMock(DbEntitiesTestCases.PersonalEvents);
+        _dbContextMock.Setup(mock => mock.PersonalEvents)
+            .Returns(dbSetMock.Object);
+        _getPersonalEventQueryHandler = new GetPersonalEventQueryHandler(_dbContextMock.Object);
+    }
+
+    [TestCase(1)]
+    [TestCase(2)]
+    public async Task Should_ReturnCorrectPersonalEvent_When_SearchingForExistingId(int id)
+    {
+        // Act
+        PersonalEventEntity personalEvent = await _getPersonalEventQueryHandler.Handle(new GetPersonalEventQuery {Id = id});
+
+        // Assert
+        personalEvent.ID.Should().Be(id);
+    }
+
+    [TestCase(DbEntitiesTestCases.MovedToBerlin)]
+    [TestCase(DbEntitiesTestCases.SawTheMoon)]
+    public async Task Should_ReturnCorrectPersonalEvent_When_SearchingForExistingTitle(string title)
+    {
+        // Act
+        PersonalEventEntity personalEvent = await _getPersonalEventQueryHandler.Handle(new GetPersonalEventQuery { Title = title });
+
+        // Assert
+        personalEvent.Title.Should().Be(title);
+    }
+
+    [TestCase(-1)]
+    [TestCase(0)]
+    [TestCase(100000)]
+    public async Task Should_ReturnNull_When_SearchingForNonExistantId(int id)
+    {
+        // Act
+        PersonalEventEntity personalEvent = await _getPersonalEventQueryHandler.Handle(new GetPersonalEventQuery { Id = id });
+
+        // Assert
+        personalEvent.Should().BeNull();
+    }
+
+    [TestCase("Nothing")]
+    [TestCase("")]
+    public async Task Should_ReturnNull_When_SearchingForNonExistantTitle(string title)
+    {
+        // Act
+        PersonalEventEntity personalEvent = await _getPersonalEventQueryHandler.Handle(new GetPersonalEventQuery { Title = title });
+
+        // Assert
+        personalEvent.Should().BeNull();
+    }
+}

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetSourceQueryHandlerTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetSourceQueryHandlerTests.cs
@@ -12,21 +12,21 @@ using YaronEfrat.Yiyo.Application.Queries;
 
 namespace YaronEfrat.Yiyo.Application.UnitTests.Queries;
 
-internal class GetMottoQueryHandlerTests
+internal class GetSourceQueryHandlerTests
 {
     private Mock<IApplicationDbContext> _dbContextMock;
 
-    private GetMottoQueryHandler _getMottoQueryHandler;
+    private GetSourceQueryHandler _getSourceQueryHandler;
 
     [SetUp]
     public void SetUp()
     {
         _dbContextMock = new Mock<IApplicationDbContext>();
 
-        Mock<DbSet<MottoEntity>> dbSetMock = TestFixtures.DbSetMock(DbEntitiesTestCases.Mottos);
-        _dbContextMock.Setup(mock => mock.Mottos)
+        Mock<DbSet<SourceEntity>> dbSetMock = TestFixtures.DbSetMock(DbEntitiesTestCases.Sources);
+        _dbContextMock.Setup(mock => mock.Sources)
             .Returns(dbSetMock.Object);
-        _getMottoQueryHandler = new GetMottoQueryHandler(_dbContextMock.Object);
+        _getSourceQueryHandler = new GetSourceQueryHandler(_dbContextMock.Object);
     }
 
     [TestCase(1)]
@@ -34,10 +34,10 @@ internal class GetMottoQueryHandlerTests
     public async Task Should_ReturnCorrectFeeling_When_SearchingForExistingId(int id)
     {
         // Act
-        MottoEntity motto = await _getMottoQueryHandler.Handle(new GetMottoQuery {Id = id});
+        SourceEntity source = await _getSourceQueryHandler.Handle(new GetSourceQuery {Id = id});
 
         // Assert
-        motto.ID.Should().Be(id);
+        source.ID.Should().Be(id);
     }
 
     [TestCase(-1)]
@@ -46,9 +46,9 @@ internal class GetMottoQueryHandlerTests
     public async Task Should_ReturnNull_When_SearchingForNonExistantId(int id)
     {
         // Act
-        MottoEntity motto = await _getMottoQueryHandler.Handle(new GetMottoQuery { Id = id });
+        SourceEntity source = await _getSourceQueryHandler.Handle(new GetSourceQuery { Id = id });
 
         // Assert
-        motto.Should().BeNull();
+        source.Should().BeNull();
     }
 }

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetWorldEventQueryHandlerTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetWorldEventQueryHandlerTests.cs
@@ -1,0 +1,76 @@
+﻿using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using NUnit.Framework;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+using YaronEfrat.Yiyo.Application.Models;
+using YaronEfrat.Yiyo.Application.Queries;
+
+namespace YaronEfrat.Yiyo.Application.UnitTests.Queries;
+
+internal class GetWorldEventQueryHandlerTests
+{
+    private Mock<IApplicationDbContext> _dbContextMock;
+
+    private GetWorldEventQueryHandler _getWorldEventQueryHandler;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _dbContextMock = new Mock<IApplicationDbContext>();
+
+        Mock<DbSet<WorldEventEntity>> dbSetMock = TestFixtures.DbSetMock(DbEntitiesTestCases.WorldEvents);
+        _dbContextMock.Setup(mock => mock.WorldEvents)
+            .Returns(dbSetMock.Object);
+        _getWorldEventQueryHandler = new GetWorldEventQueryHandler(_dbContextMock.Object);
+    }
+
+    [TestCase(1)]
+    [TestCase(2)]
+    public async Task Should_ReturnCorrectWorldEvent_When_SearchingForExistingId(int id)
+    {
+        // Act
+        WorldEventEntity worldEvent = await _getWorldEventQueryHandler.Handle(new GetWorldEventQuery {Id = id});
+
+        // Assert
+        worldEvent.ID.Should().Be(id);
+    }
+
+    [TestCase(DbEntitiesTestCases.Corona)]
+    [TestCase(DbEntitiesTestCases.War)]
+    public async Task Should_ReturnCorrectWorldEvent_When_SearchingForExistingTitle(string title)
+    {
+        // Act
+        WorldEventEntity worldEvent = await _getWorldEventQueryHandler.Handle(new GetWorldEventQuery { Title = title });
+
+        // Assert
+        worldEvent.Title.Should().Be(title);
+    }
+
+    [TestCase(-1)]
+    [TestCase(0)]
+    [TestCase(100000)]
+    public async Task Should_ReturnNull_When_SearchingForNonExistantId(int id)
+    {
+        // Act
+        WorldEventEntity worldEvent = await _getWorldEventQueryHandler.Handle(new GetWorldEventQuery { Id = id });
+
+        // Assert
+        worldEvent.Should().BeNull();
+    }
+
+    [TestCase("Nothing")]
+    [TestCase("")]
+    public async Task Should_ReturnNull_When_SearchingForNonExistantTitle(string title)
+    {
+        // Act
+        WorldEventEntity worldEvent = await _getWorldEventQueryHandler.Handle(new GetWorldEventQuery { Title = title });
+
+        // Assert
+        worldEvent.Should().BeNull();
+    }
+}

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetYearInQueryHandlerTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetYearInQueryHandlerTests.cs
@@ -1,0 +1,54 @@
+﻿using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using NUnit.Framework;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+using YaronEfrat.Yiyo.Application.Models;
+using YaronEfrat.Yiyo.Application.Queries;
+
+namespace YaronEfrat.Yiyo.Application.UnitTests.Queries;
+
+internal class GetYearInQueryHandlerTests
+{
+    private Mock<IApplicationDbContext> _dbContextMock;
+
+    private GetYearInQueryHandler _getYearInQueryHandler;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _dbContextMock = new Mock<IApplicationDbContext>();
+
+        Mock<DbSet<YearInEntity>> dbSetMock = TestFixtures.DbSetMock(DbEntitiesTestCases.YearIns);
+        _dbContextMock.Setup(mock => mock.YearIns)
+            .Returns(dbSetMock.Object);
+        _getYearInQueryHandler = new GetYearInQueryHandler(_dbContextMock.Object);
+    }
+
+    [TestCase(1)]
+    [TestCase(2)]
+    public async Task Should_ReturnCorrectFeeling_When_SearchingForExistingId(int id)
+    {
+        // Act
+        YearInEntity yearIn = await _getYearInQueryHandler.Handle(new GetYearInQuery {Id = id});
+
+        // Assert
+        yearIn.ID.Should().Be(id);
+    }
+
+    [TestCase(-1)]
+    [TestCase(0)]
+    [TestCase(100000)]
+    public async Task Should_ReturnNull_When_SearchingForNonExistantId(int id)
+    {
+        // Act
+        YearInEntity yearIn = await _getYearInQueryHandler.Handle(new GetYearInQuery { Id = id });
+
+        // Assert
+        yearIn.Should().BeNull();
+    }
+}

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetYearOutQueryHandlerTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Queries/GetYearOutQueryHandlerTests.cs
@@ -1,0 +1,54 @@
+﻿using FluentAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using NUnit.Framework;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+using YaronEfrat.Yiyo.Application.Models;
+using YaronEfrat.Yiyo.Application.Queries;
+
+namespace YaronEfrat.Yiyo.Application.UnitTests.Queries;
+
+internal class GetYearOutQueryHandlerTests
+{
+    private Mock<IApplicationDbContext> _dbContextMock;
+
+    private GetYearOutQueryHandler _getYearOutQueryHandler;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _dbContextMock = new Mock<IApplicationDbContext>();
+
+        Mock<DbSet<YearOutEntity>> dbSetMock = TestFixtures.DbSetMock(DbEntitiesTestCases.YearOuts);
+        _dbContextMock.Setup(mock => mock.YearOuts)
+            .Returns(dbSetMock.Object);
+        _getYearOutQueryHandler = new GetYearOutQueryHandler(_dbContextMock.Object);
+    }
+
+    [TestCase(1)]
+    [TestCase(2)]
+    public async Task Should_ReturnCorrectFeeling_When_SearchingForExistingId(int id)
+    {
+        // Act
+        YearOutEntity yearOut = await _getYearOutQueryHandler.Handle(new GetYearOutQuery {Id = id});
+
+        // Assert
+        yearOut.ID.Should().Be(id);
+    }
+
+    [TestCase(-1)]
+    [TestCase(0)]
+    [TestCase(100000)]
+    public async Task Should_ReturnNull_When_SearchingForNonExistantId(int id)
+    {
+        // Act
+        YearOutEntity yearOut = await _getYearOutQueryHandler.Handle(new GetYearOutQuery { Id = id });
+
+        // Assert
+        yearOut.Should().BeNull();
+    }
+}

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/TestFixtures.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/TestFixtures.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+using Moq;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+
+namespace YaronEfrat.Yiyo.Application.UnitTests;
+
+internal class TestFixtures
+{
+    internal static Mock<DbSet<T>> DbSetMock<T>(IReadOnlyList<T> sourceList) where T : class, IDbEntity
+    {
+        IQueryable<T> queryable = sourceList.AsQueryable();
+        Mock<DbSet<T>> dbSetMock = new();
+        dbSetMock.As<IQueryable<T>>().Setup(m => m.Provider).Returns(queryable.Provider);
+        dbSetMock.As<IQueryable<T>>().Setup(m => m.Expression).Returns(queryable.Expression);
+        dbSetMock.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(queryable.ElementType);
+        dbSetMock.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(() => queryable.GetEnumerator());
+        return dbSetMock;
+    }
+}

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/YaronEfrat.Yiyo.Application.UnitTests.csproj
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/YaronEfrat.Yiyo.Application.UnitTests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
     <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     <PackageReference Include="System.Linq.Async.Queryable" Version="6.0.1" />
   </ItemGroup>
 

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/YaronEfrat.Yiyo.Application.UnitTests.csproj
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/YaronEfrat.Yiyo.Application.UnitTests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.11.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.9" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="System.Linq.Async.Queryable" Version="6.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\YaronEfrat.Yiyo.Application\YaronEfrat.Yiyo.Application.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>YaronEfrat.Yiyo.Application</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
In this PR, we create all of the query classes (and their handlers and tests) for the entities.

We are using the MediatR framework as recommended in [this article](https://blog.jacobsdata.com/2020/02/19/a-brief-intro-to-clean-architecture-clean-ddd-and-cqrs#:~:text=you%20can%20utilize%20a%20pre%2Dbuilt%20messaging%20framework%2C%20such%20as%20MediatR) to take care of the connection between requests and handlers and will be using it in the future for the rest of the CQRS classes.
