### PR TITLE
[YIYO-3] ci: Add basic gitversion

### DIFF
--- a/.github/GitVersion.yaml
+++ b/.github/GitVersion.yaml
@@ -1,0 +1,1 @@
+mode: Mainline

--- a/.github/GitVersion.yaml
+++ b/.github/GitVersion.yaml
@@ -1,1 +1,2 @@
 mode: Mainline
+commit-message-incrementing: MergeMessageOnly

--- a/.github/GitVersion.yaml
+++ b/.github/GitVersion.yaml
@@ -1,2 +1,3 @@
 mode: Mainline
 commit-message-incrementing: MergeMessageOnly
+next-version: 0.1.0

--- a/.github/GitVersion.yaml
+++ b/.github/GitVersion.yaml
@@ -1,3 +1,2 @@
 mode: Mainline
 commit-message-incrementing: MergeMessageOnly
-next-version: 0.1.0

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+In this PR,
+
++semver: patch
+(change to minor, major or none as necessary)

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -50,4 +50,4 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal /p:AssemblyVersion=${{ needs.gitVersion.outputs.assemblySemFileVer }} /p:FileVersion=${{ needs.gitVersion.outputs.assemblySemFileVer }} /p:InformationalVersion=${{ needs.gitVersion.outputs.informationalVersion }}

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -12,6 +12,13 @@ on:
 jobs:
   gitVersion:
     runs-on: ubuntu-latest
+    outputs:
+      branchName: ${{ steps.gitversion.outputs.branchName }} # To use an output in another job, you have to map it to a job output.
+      semVer: ${{ steps.gitversion.outputs.semVer }}
+      sha: ${{ steps.gitversion.outputs.sha }}
+      nugetVersion: ${{ steps.gitversion.outputs.nuGetVersion }}
+      assemblySemFileVer: ${{ steps.gitversion.outputs.assemblySemFileVer }}
+      informationalVersion: ${{ steps.gitversion.outputs.informationalVersion }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -25,23 +32,6 @@ jobs:
     - name: Determine Version
       id:   gitversion # id to later be referenced
       uses: gittools/actions/gitversion/execute@v0
-    - name: Display GitVersion outputs (step output)
-      run: |
-        echo "Major: ${{ steps.gitversion.outputs.major }}"
-        echo "Minor: ${{ steps.gitversion.outputs.minor }}"
-        echo "Patch: ${{ steps.gitversion.outputs.patch }}"
-        echo "PreReleaseTag: ${{ steps.gitversion.outputs.preReleaseTag }}"
-        echo "FullBuildMetaData: ${{ steps.gitversion.outputs.fullBuildMetaData }}"
-        echo "MajorMinorPatch: ${{ steps.gitversion.outputs.majorMinorPatch }}"
-        echo "SemVer: ${{ steps.gitversion.outputs.semVer }}"
-        echo "AssemblySemFileVer: ${{ steps.gitversion.outputs.assemblySemFileVer }}"
-        echo "FullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}"
-        echo "InformationalVersion: ${{ steps.gitversion.outputs.informationalVersion }}"
-        echo "BranchName: ${{ steps.gitversion.outputs.branchName }}"
-        echo "Sha: ${{ steps.gitversion.outputs.sha }}"
-        echo "NuGetVersion: ${{ steps.gitversion.outputs.nuGetVersion }}"
-        echo "CommitsSinceVersionSource: ${{ steps.gitversion.outputs.commitsSinceVersionSource }}"
-        echo "CommitDate: ${{ steps.gitversion.outputs.commitDate }}"
 
   buildAndTest:
     needs: [gitVersion]

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -53,3 +53,17 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal /p:AssemblyVersion=${{ needs.gitVersion.outputs.assemblySemFileVer }} /p:FileVersion=${{ needs.gitVersion.outputs.assemblySemFileVer }} /p:InformationalVersion=${{ needs.gitVersion.outputs.informationalVersion }}
+
+  tagAndRelease:
+    needs: [gitVersion, buildAndTest]
+    runs-on: ubuntu-latest
+    
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Tag on main
+      run: |
+          git config --global user.name "Github actions: gitversion"
+          git config --global user.email "gitversion@github-actions.com"
+          git tag -a "${{ needs.gitVersion.outputs.semVer}}" -m "Version ${{ needs.gitVersion.outputs.semVer}}"
+          git push --tags

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -34,6 +34,8 @@ jobs:
       uses: gittools/actions/gitversion/execute@v0
       with:
         additionalArguments: '/updateprojectfiles'
+        useConfigFile: true
+        configFilePath: '.github/GitVersion.yaml'
 
   buildAndTest:
     needs: [gitVersion]

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -33,7 +33,6 @@ jobs:
       id:   gitversion # id to later be referenced
       uses: gittools/actions/gitversion/execute@v0
       with:
-        updateAssemblyInfo: true
         additionalArguments: '/updateprojectfiles'
 
   buildAndTest:

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -32,6 +32,9 @@ jobs:
     - name: Determine Version
       id:   gitversion # id to later be referenced
       uses: gittools/actions/gitversion/execute@v0
+      with:
+        updateAssemblyInfo: true
+        additionalArguments: '/updateprojectfiles'
 
   buildAndTest:
     needs: [gitVersion]

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -57,6 +57,7 @@ jobs:
   tagAndRelease:
     needs: [gitVersion, buildAndTest]
     runs-on: ubuntu-latest
+    if: contains(needs.gitVersion.outputs.branchName, 'main')
     permissions:
       contents: write
     

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -57,6 +57,8 @@ jobs:
   tagAndRelease:
     needs: [gitVersion, buildAndTest]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     
 
     steps:

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -10,8 +10,40 @@ on:
     branches: [ "main" ]
 
 jobs:
-  buildAndTest:
+  gitVersion:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Install GitVersion
+      uses: gittools/actions/gitversion/setup@v0
+      with:
+        versionSpec: '6.x'
+        preferLatestVersion: true
+    - name: Determine Version
+      uses: gittools/actions/gitversion/execute@v0
+    - name: Display GitVersion outputs (step output)
+      run: |
+        echo "Major: ${{ steps.gitversion.outputs.major }}"
+        echo "Minor: ${{ steps.gitversion.outputs.minor }}"
+        echo "Patch: ${{ steps.gitversion.outputs.patch }}"
+        echo "PreReleaseTag: ${{ steps.gitversion.outputs.preReleaseTag }}"
+        echo "FullBuildMetaData: ${{ steps.gitversion.outputs.fullBuildMetaData }}"
+        echo "MajorMinorPatch: ${{ steps.gitversion.outputs.majorMinorPatch }}"
+        echo "SemVer: ${{ steps.gitversion.outputs.semVer }}"
+        echo "AssemblySemFileVer: ${{ steps.gitversion.outputs.assemblySemFileVer }}"
+        echo "FullSemVer: ${{ steps.gitversion.outputs.fullSemVer }}"
+        echo "InformationalVersion: ${{ steps.gitversion.outputs.informationalVersion }}"
+        echo "BranchName: ${{ steps.gitversion.outputs.branchName }}"
+        echo "Sha: ${{ steps.gitversion.outputs.sha }}"
+        echo "NuGetVersion: ${{ steps.gitversion.outputs.nuGetVersion }}"
+        echo "CommitsSinceVersionSource: ${{ steps.gitversion.outputs.commitsSinceVersionSource }}"
+        echo "CommitDate: ${{ steps.gitversion.outputs.commitDate }}"
 
+  buildAndTest:
+    needs: [gitVersion]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@v0
       with:
-        versionSpec: '6.x'
+        versionSpec: '5.x'
         preferLatestVersion: true
     - name: Determine Version
       uses: gittools/actions/gitversion/execute@v0

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -23,6 +23,7 @@ jobs:
         versionSpec: '5.x'
         preferLatestVersion: true
     - name: Determine Version
+      id:   gitversion # id to later be referenced
       uses: gittools/actions/gitversion/execute@v0
     - name: Display GitVersion outputs (step output)
       run: |

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # year-in-year-out
+[![Continous integration pipeline](https://github.com/yaron-E92/year-in-year-out/actions/workflows/ci-pipeline.yaml/badge.svg)](https://github.com/yaron-E92/year-in-year-out/actions/workflows/ci-pipeline.yaml)
+
 This web app allows one to perform a year in year out end of year reflection


### PR DESCRIPTION
In this PR, we add a Gitversion support in the CI pipeline in order to properly follow the semantic versioning

+semver: minor