### PR TITLE
[24] ci: Add publish test results step in ci

### DIFF
--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -19,6 +19,7 @@ jobs:
       nugetVersion: ${{ steps.gitversion.outputs.nuGetVersion }}
       assemblySemFileVer: ${{ steps.gitversion.outputs.assemblySemFileVer }}
       informationalVersion: ${{ steps.gitversion.outputs.informationalVersion }}
+
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -40,6 +41,9 @@ jobs:
   buildAndTest:
     needs: [gitVersion]
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: write
 
     steps:
     - uses: actions/checkout@v3
@@ -68,7 +72,6 @@ jobs:
     if: contains(needs.gitVersion.outputs.branchName, 'main')
     permissions:
       contents: write
-    
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -53,6 +53,14 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal /p:AssemblyVersion=${{ needs.gitVersion.outputs.assemblySemFileVer }} /p:FileVersion=${{ needs.gitVersion.outputs.assemblySemFileVer }} /p:InformationalVersion=${{ needs.gitVersion.outputs.informationalVersion }}
+    - name: Publish Test Results
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: always()
+      with:
+        files: |
+          test-results/**/*.xml
+          test-results/**/*.trx
+          test-results/**/*.json
 
   tagAndRelease:
     needs: [gitVersion, buildAndTest]

--- a/.github/workflows/ci-pipeline.yaml
+++ b/.github/workflows/ci-pipeline.yaml
@@ -56,15 +56,15 @@ jobs:
     - name: Build
       run: dotnet build --no-restore
     - name: Test
-      run: dotnet test --no-build --verbosity normal /p:AssemblyVersion=${{ needs.gitVersion.outputs.assemblySemFileVer }} /p:FileVersion=${{ needs.gitVersion.outputs.assemblySemFileVer }} /p:InformationalVersion=${{ needs.gitVersion.outputs.informationalVersion }}
+      run: dotnet test --logger "trx" --no-build --verbosity normal /p:AssemblyVersion=${{ needs.gitVersion.outputs.assemblySemFileVer }} /p:FileVersion=${{ needs.gitVersion.outputs.assemblySemFileVer }} /p:InformationalVersion=${{ needs.gitVersion.outputs.informationalVersion }}
     - name: Publish Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
       with:
         files: |
-          test-results/**/*.xml
-          test-results/**/*.trx
-          test-results/**/*.json
+          tests/**/TestResults/*.xml
+          tests/**/TestResults/*.trx
+          tests/**/TestResults/*.json
 
   tagAndRelease:
     needs: [gitVersion, buildAndTest]


### PR DESCRIPTION
In this PR, we add a step to publish the test results as part of the CI pipeline

+semver: none
