### PR TITLE
Feature/29 setup basic persistence layer

### DIFF
--- a/YearInYearOut.sln
+++ b/YearInYearOut.sln
@@ -9,7 +9,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YaronEfrat.Yiyo.Domain.Refl
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YaronEfrat.Yiyo.Application", "src\YaronEfrat.Yiyo.Application\YaronEfrat.Yiyo.Application.csproj", "{CC9590A8-F3D0-448E-A07E-41114ED80963}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YaronEfrat.Yiyo.Application.UnitTests", "tests\YaronEfrat.Yiyo.Application.UnitTests\YaronEfrat.Yiyo.Application.UnitTests.csproj", "{036AF25E-213F-4250-AA4B-AD86F591C2DB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "YaronEfrat.Yiyo.Application.UnitTests", "tests\YaronEfrat.Yiyo.Application.UnitTests\YaronEfrat.Yiyo.Application.UnitTests.csproj", "{036AF25E-213F-4250-AA4B-AD86F591C2DB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YaronEfrat.Yiyo.Persistence", "src\YaronEfrat.Yiyo.Persistence\YaronEfrat.Yiyo.Persistence.csproj", "{831B6EF0-D97C-470A-AEC3-88AF40CF9637}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +35,10 @@ Global
 		{036AF25E-213F-4250-AA4B-AD86F591C2DB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{036AF25E-213F-4250-AA4B-AD86F591C2DB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{036AF25E-213F-4250-AA4B-AD86F591C2DB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{831B6EF0-D97C-470A-AEC3-88AF40CF9637}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{831B6EF0-D97C-470A-AEC3-88AF40CF9637}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{831B6EF0-D97C-470A-AEC3-88AF40CF9637}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{831B6EF0-D97C-470A-AEC3-88AF40CF9637}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/YaronEfrat.Yiyo.Persistence/ApplicationDbContext.cs
+++ b/src/YaronEfrat.Yiyo.Persistence/ApplicationDbContext.cs
@@ -1,0 +1,23 @@
+﻿using System.Data;
+
+using Microsoft.EntityFrameworkCore;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+using YaronEfrat.Yiyo.Application.Models;
+
+namespace YaronEfrat.Yiyo.Persistence;
+
+public class ApplicationDbContext : DbContext, IApplicationDbContext
+{
+    public IDbConnection Connection => Database.GetDbConnection();
+    public DbSet<FeelingEntity> Feelings { get; set; } = default!;
+    public bool HasChanges => ChangeTracker.HasChanges();
+    public DbSet<MottoEntity> Mottos { get; set; } = default!;
+    public DbSet<PersonalEventEntity> PersonalEvents { get; set; } = default!;
+    public DbSet<SourceEntity> Sources { get; set; } = default!;
+    public DbSet<WorldEventEntity> WorldEvents { get; set; } = default!;
+    public DbSet<YearInEntity> YearIns { get; set; } = default!;
+    public DbSet<YearOutEntity> YearOuts { get; set; } = default!;
+
+    public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) {}
+}

--- a/src/YaronEfrat.Yiyo.Persistence/PersistenceLayerDependencyInjection.cs
+++ b/src/YaronEfrat.Yiyo.Persistence/PersistenceLayerDependencyInjection.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+using YaronEfrat.Yiyo.Application.Interfaces;
+
+namespace YaronEfrat.Yiyo.Persistence;
+
+public static class PersistenceLayerDependencyInjection
+{
+    private const string DefaultConnection = "DefaultConnection";
+
+    public static void AddPersistenceLayerDependencyInjection(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddDbContext<ApplicationDbContext>(options =>
+            options.UseNpgsql(configuration.GetConnectionString(DefaultConnection)));
+
+        services.AddScoped<IApplicationDbContext>(provider =>
+            provider.GetService<ApplicationDbContext>() ?? throw new Exception("Could not get DB context."));
+    }
+}

--- a/src/YaronEfrat.Yiyo.Persistence/YaronEfrat.Yiyo.Persistence.csproj
+++ b/src/YaronEfrat.Yiyo.Persistence/YaronEfrat.Yiyo.Persistence.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.9" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\YaronEfrat.Yiyo.Application\YaronEfrat.Yiyo.Application.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/YaronEfrat.Yiyo.Persistence/YaronEfrat.Yiyo.Persistence.csproj
+++ b/src/YaronEfrat.Yiyo.Persistence/YaronEfrat.Yiyo.Persistence.csproj
@@ -8,7 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.10" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In this PR, we set up a persistence project, put in it a very basic implementation of `IApplicationDbContext`, and provide rudimentary DI with `AddDbContext` and registering the implementation mentioned before

+semver: minor
