### PR TITLE
Fix/37 fix database model to allow many to many relationships

### DIFF
--- a/src/YaronEfrat.Yiyo.Application/Commands/Feelings/AddFeelingCommand.cs
+++ b/src/YaronEfrat.Yiyo.Application/Commands/Feelings/AddFeelingCommand.cs
@@ -43,6 +43,9 @@ public class AddFeelingCommandHandler : IRequestHandler<AddFeelingCommand, Feeli
         domainFeeling.Validate();
 
         _domainToDbMapper.Map(domainFeeling, feelingEntity);
+
+        _context.PersonalEvents.AttachRange(feelingEntity.PersonalEvents);
+
         await _context.Feelings.AddAsync(feelingEntity, cancellationToken);
         await _context.SaveChangesAsync(cancellationToken);
         return feelingEntity;

--- a/src/YaronEfrat.Yiyo.Application/Commands/Feelings/AddFeelingCommand.cs
+++ b/src/YaronEfrat.Yiyo.Application/Commands/Feelings/AddFeelingCommand.cs
@@ -38,16 +38,16 @@ public class AddFeelingCommandHandler : IRequestHandler<AddFeelingCommand, Feeli
             return null!;
         }
 
-        FeelingEntity feelingEntity = request.FeelingEntity;
-        Feeling domainFeeling = _dbToDomainMapper.Map(feelingEntity);
-        domainFeeling.Validate();
+        FeelingEntity dbEntity = request.FeelingEntity;
+        Feeling domainEntity = _dbToDomainMapper.Map(dbEntity);
+        domainEntity.Validate();
 
-        _domainToDbMapper.Map(domainFeeling, feelingEntity);
+        _domainToDbMapper.Map(domainEntity, dbEntity);
 
-        _context.PersonalEvents.AttachRange(feelingEntity.PersonalEvents);
+        _context.PersonalEvents.AttachRange(dbEntity.PersonalEvents);
 
-        await _context.Feelings.AddAsync(feelingEntity, cancellationToken);
+        await _context.Feelings.AddAsync(dbEntity, cancellationToken);
         await _context.SaveChangesAsync(cancellationToken);
-        return feelingEntity;
+        return dbEntity;
     }
 }

--- a/src/YaronEfrat.Yiyo.Application/Commands/Mottos/AddMottoCommand.cs
+++ b/src/YaronEfrat.Yiyo.Application/Commands/Mottos/AddMottoCommand.cs
@@ -39,13 +39,13 @@ public class AddMottoCommandHandler : IRequestHandler<AddMottoCommand, MottoEnti
             return null!;
         }
 
-        MottoEntity mottoEntity = request.MottoEntity;
-        Motto domainMotto = _dbToDomainMapper.Map(mottoEntity);
-        domainMotto.Validate();
+        MottoEntity dbEntity = request.MottoEntity;
+        Motto domainEntity = _dbToDomainMapper.Map(dbEntity);
+        domainEntity.Validate();
 
-        _domainToDbMapper.Map(domainMotto, mottoEntity);
-        await _context.Mottos.AddAsync(mottoEntity, cancellationToken);
+        _domainToDbMapper.Map(domainEntity, dbEntity);
+        await _context.Mottos.AddAsync(dbEntity, cancellationToken);
         await _context.SaveChangesAsync(cancellationToken);
-        return mottoEntity;
+        return dbEntity;
     }
 }

--- a/src/YaronEfrat.Yiyo.Application/Commands/PersonalEvents/AddPersonalEventCommand.cs
+++ b/src/YaronEfrat.Yiyo.Application/Commands/PersonalEvents/AddPersonalEventCommand.cs
@@ -40,13 +40,13 @@ public class AddPersonalEventCommandHandler : IRequestHandler<AddPersonalEventCo
             return null!;
         }
 
-        PersonalEventEntity personalEventEntity = request.PersonalEventEntity;
-        PersonalEvent domainPersonalEvent = _dbToDomainMapper.Map(personalEventEntity);
-        domainPersonalEvent.Validate();
+        PersonalEventEntity dbEntity = request.PersonalEventEntity;
+        PersonalEvent domainEntity = _dbToDomainMapper.Map(dbEntity);
+        domainEntity.Validate();
 
-        _domainToDbMapper.Map(domainPersonalEvent, personalEventEntity);
-        await _context.PersonalEvents.AddAsync(personalEventEntity, cancellationToken);
+        _domainToDbMapper.Map(domainEntity, dbEntity);
+        await _context.PersonalEvents.AddAsync(dbEntity, cancellationToken);
         await _context.SaveChangesAsync(cancellationToken);
-        return personalEventEntity;
+        return dbEntity;
     }
 }

--- a/src/YaronEfrat.Yiyo.Application/Commands/Sources/AddSourceCommand.cs
+++ b/src/YaronEfrat.Yiyo.Application/Commands/Sources/AddSourceCommand.cs
@@ -32,13 +32,13 @@ public class AddSourceCommandHandler : IRequestHandler<AddSourceCommand, SourceE
             return null!;
         }
 
-        SourceEntity sourceEntity = request.SourceEntity;
-        await _context.Sources.AddAsync(sourceEntity, cancellationToken);
+        SourceEntity dbEntity = request.SourceEntity;
+        await _context.Sources.AddAsync(dbEntity, cancellationToken);
         if (!request.IsChildCommand)
         {
             await _context.SaveChangesAsync(cancellationToken);
         }
         
-        return sourceEntity;
+        return dbEntity;
     }
 }

--- a/src/YaronEfrat.Yiyo.Application/Commands/Sources/UpdateSourceCommand.cs
+++ b/src/YaronEfrat.Yiyo.Application/Commands/Sources/UpdateSourceCommand.cs
@@ -28,24 +28,24 @@ public class UpdateSourceCommandHandler : IRequestHandler<UpdateSourceCommand, S
             return null!;
         }
 
-        SourceEntity sourceEntity = request.SourceEntity;
-        if (sourceEntity is { ID: <=0 } or null)
+        SourceEntity dbEntity = request.SourceEntity;
+        if (dbEntity is { ID: <=0 } or null)
         {
             return null!;
         }
 
-        SourceEntity existingSourceEntity = _context.Sources.SingleOrDefault(s => s.ID == sourceEntity.ID, null!);
-        if (existingSourceEntity == null!)
+        SourceEntity existingDbEntity = _context.Sources.SingleOrDefault(s => s.ID == dbEntity.ID, null!);
+        if (existingDbEntity == null!)
         {
             return null!;
         }
 
-        existingSourceEntity.Url = sourceEntity.Url;
+        existingDbEntity.Url = dbEntity.Url;
         if (!request.IsChildCommand)
         {
             await _context.SaveChangesAsync(cancellationToken);
         }
 
-        return existingSourceEntity;
+        return existingDbEntity;
     }
 }

--- a/src/YaronEfrat.Yiyo.Application/Commands/WorldEvents/AddWorldEventCommand.cs
+++ b/src/YaronEfrat.Yiyo.Application/Commands/WorldEvents/AddWorldEventCommand.cs
@@ -42,15 +42,15 @@ public class AddWorldEventCommandHandler : IRequestHandler<AddWorldEventCommand,
             return null!;
         }
 
-        WorldEventEntity worldEventEntity = request.WorldEventEntity;
-        WorldEvent domainWorldEvent = _dbToDomainMapper.Map(worldEventEntity);
-        domainWorldEvent.Validate();
+        WorldEventEntity dbEntity = request.WorldEventEntity;
+        WorldEvent domainEntity = _dbToDomainMapper.Map(dbEntity);
+        domainEntity.Validate();
 
-        _domainToDbMapper.Map(domainWorldEvent, worldEventEntity);
-        await HandleSources(worldEventEntity.Sources, cancellationToken);
-        await _context.WorldEvents.AddAsync(worldEventEntity, cancellationToken);
+        _domainToDbMapper.Map(domainEntity, dbEntity);
+        await HandleSources(dbEntity.Sources, cancellationToken);
+        await _context.WorldEvents.AddAsync(dbEntity, cancellationToken);
         await _context.SaveChangesAsync(cancellationToken);
-        return worldEventEntity;
+        return dbEntity;
     }
 
     private async Task HandleSources(IEnumerable<SourceEntity> sources, CancellationToken cancellationToken)

--- a/src/YaronEfrat.Yiyo.Application/Commands/YearIns/AddYearInCommand.cs
+++ b/src/YaronEfrat.Yiyo.Application/Commands/YearIns/AddYearInCommand.cs
@@ -37,18 +37,18 @@ public class AddYearInCommandHandler : IRequestHandler<AddYearInCommand, YearInE
             return null!;
         }
 
-        YearInEntity yearInEntity = request.YearInEntity;
-        YearIn yearIn = _dbToDomainMapper.Map(yearInEntity);
-        yearIn.Validate();
+        YearInEntity dbEntity = request.YearInEntity;
+        YearIn domainEntity = _dbToDomainMapper.Map(dbEntity);
+        domainEntity.Validate();
 
-        _domainToDbMapper.Map(yearIn, yearInEntity);
+        _domainToDbMapper.Map(domainEntity, dbEntity);
 
-        AttachRelations(yearInEntity);
+        AttachRelations(dbEntity);
 
-        await _context.YearIns.AddAsync(yearInEntity, cancellationToken);
+        await _context.YearIns.AddAsync(dbEntity, cancellationToken);
         await _context.SaveChangesAsync(cancellationToken);
 
-        return yearInEntity;
+        return dbEntity;
     }
 
     private void AttachRelations(YearInEntity yearInEntity)

--- a/src/YaronEfrat.Yiyo.Application/Commands/YearIns/AddYearInCommand.cs
+++ b/src/YaronEfrat.Yiyo.Application/Commands/YearIns/AddYearInCommand.cs
@@ -43,9 +43,22 @@ public class AddYearInCommandHandler : IRequestHandler<AddYearInCommand, YearInE
 
         _domainToDbMapper.Map(yearIn, yearInEntity);
 
+        AttachRelations(yearInEntity);
+
         await _context.YearIns.AddAsync(yearInEntity, cancellationToken);
         await _context.SaveChangesAsync(cancellationToken);
 
         return yearInEntity;
+    }
+
+    private void AttachRelations(YearInEntity yearInEntity)
+    {
+        _context.Feelings.AttachRange(yearInEntity.Feelings);
+        if (yearInEntity.Motto != null)
+        {
+            _context.Mottos.Attach(yearInEntity.Motto);
+        }
+        _context.PersonalEvents.AttachRange(yearInEntity.PersonalEvents);
+        _context.WorldEvents.AttachRange(yearInEntity.WorldEvents);
     }
 }

--- a/src/YaronEfrat.Yiyo.Application/Commands/YearOuts/AddYearOutCommand.cs
+++ b/src/YaronEfrat.Yiyo.Application/Commands/YearOuts/AddYearOutCommand.cs
@@ -43,9 +43,21 @@ public class AddYearOutCommandHandler : IRequestHandler<AddYearOutCommand, YearO
 
         _domainToDbMapper.Map(yearOut, yearOutEntity);
 
+        AttachRelations(yearOutEntity);
+
         await _context.YearOuts.AddAsync(yearOutEntity, cancellationToken);
         await _context.SaveChangesAsync(cancellationToken);
 
         return yearOutEntity;
+    }
+
+    private void AttachRelations(YearOutEntity yearOutEntity)
+    {
+        _context.Feelings.AttachRange(yearOutEntity.Feelings);
+        if (yearOutEntity.Motto != null)
+        {
+            _context.Mottos.Attach(yearOutEntity.Motto);
+        }
+        _context.PersonalEvents.AttachRange(yearOutEntity.PersonalEvents);
     }
 }

--- a/src/YaronEfrat.Yiyo.Application/Commands/YearOuts/AddYearOutCommand.cs
+++ b/src/YaronEfrat.Yiyo.Application/Commands/YearOuts/AddYearOutCommand.cs
@@ -37,18 +37,18 @@ public class AddYearOutCommandHandler : IRequestHandler<AddYearOutCommand, YearO
             return null!;
         }
 
-        YearOutEntity yearOutEntity = request.YearOutEntity;
-        YearOut yearOut = _dbToDomainMapper.Map(yearOutEntity);
-        yearOut.Validate();
+        YearOutEntity dbEntity = request.YearOutEntity;
+        YearOut domainEntity = _dbToDomainMapper.Map(dbEntity);
+        domainEntity.Validate();
 
-        _domainToDbMapper.Map(yearOut, yearOutEntity);
+        _domainToDbMapper.Map(domainEntity, dbEntity);
 
-        AttachRelations(yearOutEntity);
+        AttachRelations(dbEntity);
 
-        await _context.YearOuts.AddAsync(yearOutEntity, cancellationToken);
+        await _context.YearOuts.AddAsync(dbEntity, cancellationToken);
         await _context.SaveChangesAsync(cancellationToken);
 
-        return yearOutEntity;
+        return dbEntity;
     }
 
     private void AttachRelations(YearOutEntity yearOutEntity)

--- a/src/YaronEfrat.Yiyo.Application/Queries/Feelings/GetFeelingListQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/Feelings/GetFeelingListQuery.cs
@@ -26,11 +26,11 @@ public class GetFeelingListQueryHandler : IRequestHandler<GetFeelingListQuery, F
     {
         if (request.Ids == null!)
         {
-            return await _context.Feelings.ToArrayAsync(cancellationToken);
+            return await _context.Feelings.AsNoTracking().ToArrayAsync(cancellationToken);
         }
 
         // TODO [#18]: add query validator to validate all ids are positive
-        return await _context.Feelings
+        return await _context.Feelings.AsNoTracking()
             .Where(pe => request.Ids.Contains(pe.ID))
             .ToArrayAsync(cancellationToken);
     }

--- a/src/YaronEfrat.Yiyo.Application/Queries/Feelings/GetFeelingQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/Feelings/GetFeelingQuery.cs
@@ -18,6 +18,9 @@ public class GetFeelingQueryHandler : IRequestHandler<GetFeelingQuery, FeelingEn
 {
     private readonly IApplicationDbContext _context;
 
+    private IQueryable<FeelingEntity> FeelingsQueryable =>
+        _context.Feelings.Include(e => e.PersonalEvents).AsNoTracking();
+
     public GetFeelingQueryHandler(IApplicationDbContext context)
     {
         _context = context;
@@ -27,13 +30,13 @@ public class GetFeelingQueryHandler : IRequestHandler<GetFeelingQuery, FeelingEn
     {
         if (request.Id > 0)
         {
-            return (await _context.Feelings.AsNoTracking()
+            return (await FeelingsQueryable
                 .SingleOrDefaultAsync(
                     feel => feel.ID.Equals(request.Id), cancellationToken))!;
         }
 
         return (!string.IsNullOrWhiteSpace(request.Title)
-            ? await _context.Feelings.AsNoTracking()
+            ? await FeelingsQueryable
                 .SingleOrDefaultAsync(feel => feel.Title!.Equals(request.Title),
                     cancellationToken)
             : null)!;

--- a/src/YaronEfrat.Yiyo.Application/Queries/Feelings/GetFeelingQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/Feelings/GetFeelingQuery.cs
@@ -27,12 +27,15 @@ public class GetFeelingQueryHandler : IRequestHandler<GetFeelingQuery, FeelingEn
     {
         if (request.Id > 0)
         {
-            return (await _context.Feelings.SingleOrDefaultAsync(
-                feel => feel.ID.Equals(request.Id), cancellationToken))!;
+            return (await _context.Feelings.AsNoTracking()
+                .SingleOrDefaultAsync(
+                    feel => feel.ID.Equals(request.Id), cancellationToken))!;
         }
 
         return (!string.IsNullOrWhiteSpace(request.Title)
-            ? await _context.Feelings.SingleOrDefaultAsync(feel => feel.Title!.Equals(request.Title), cancellationToken)
+            ? await _context.Feelings.AsNoTracking()
+                .SingleOrDefaultAsync(feel => feel.Title!.Equals(request.Title),
+                    cancellationToken)
             : null)!;
     }
 }

--- a/src/YaronEfrat.Yiyo.Application/Queries/GetMottoQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/GetMottoQuery.cs
@@ -23,6 +23,7 @@ public class GetMottoQueryHandler : IRequestHandler<GetMottoQuery, MottoEntity>
 
     public async Task<MottoEntity> Handle(GetMottoQuery request, CancellationToken cancellationToken = default)
     {
-        return (await _context.Mottos.SingleOrDefaultAsync(motto => motto.ID.Equals(request.Id), cancellationToken))!;
+        return (await _context.Mottos.AsNoTracking()
+            .SingleOrDefaultAsync(motto => motto.ID.Equals(request.Id), cancellationToken))!;
     }
 }

--- a/src/YaronEfrat.Yiyo.Application/Queries/GetSourceQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/GetSourceQuery.cs
@@ -23,7 +23,8 @@ public class GetSourceQueryHandler : IRequestHandler<GetSourceQuery, SourceEntit
 
     public async Task<SourceEntity> Handle(GetSourceQuery request, CancellationToken cancellationToken = default)
     {
-        return (await _context.Sources.SingleOrDefaultAsync(source => source.ID.Equals(request.Id),
+        return (await _context.Sources.AsNoTracking()
+            .SingleOrDefaultAsync(source => source.ID.Equals(request.Id),
             cancellationToken))!;
     }
 }

--- a/src/YaronEfrat.Yiyo.Application/Queries/GetYearInQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/GetYearInQuery.cs
@@ -23,7 +23,8 @@ public class GetYearInQueryHandler : IRequestHandler<GetYearInQuery, YearInEntit
 
     public async Task<YearInEntity> Handle(GetYearInQuery request, CancellationToken cancellationToken = default)
     {
-        return (await _context.YearIns.SingleOrDefaultAsync(yearIn => yearIn.ID.Equals(request.Id),
+        return (await _context.YearIns.AsNoTracking()
+            .SingleOrDefaultAsync(yearIn => yearIn.ID.Equals(request.Id),
             cancellationToken))!;
     }
 }

--- a/src/YaronEfrat.Yiyo.Application/Queries/GetYearInQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/GetYearInQuery.cs
@@ -16,6 +16,15 @@ public class GetYearInQueryHandler : IRequestHandler<GetYearInQuery, YearInEntit
 {
     private readonly IApplicationDbContext _context;
 
+    private IQueryable<YearInEntity> YearInQueryable =>
+        _context.YearIns
+            .Include(e => e.Feelings)
+            .Include(e => e.Motto)
+            .Include(e => e.PersonalEvents)
+            .Include(e => e.WorldEvents)
+            .AsSplitQuery()
+            .AsNoTracking();
+
     public GetYearInQueryHandler(IApplicationDbContext context)
     {
         _context = context;
@@ -23,7 +32,7 @@ public class GetYearInQueryHandler : IRequestHandler<GetYearInQuery, YearInEntit
 
     public async Task<YearInEntity> Handle(GetYearInQuery request, CancellationToken cancellationToken = default)
     {
-        return (await _context.YearIns.AsNoTracking()
+        return (await YearInQueryable
             .SingleOrDefaultAsync(yearIn => yearIn.ID.Equals(request.Id),
             cancellationToken))!;
     }

--- a/src/YaronEfrat.Yiyo.Application/Queries/GetYearOutQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/GetYearOutQuery.cs
@@ -23,7 +23,8 @@ public class GetYearOutQueryHandler : IRequestHandler<GetYearOutQuery, YearOutEn
 
     public async Task<YearOutEntity> Handle(GetYearOutQuery request, CancellationToken cancellationToken = default)
     {
-        return (await _context.YearOuts.SingleOrDefaultAsync(yearOut => yearOut.ID.Equals(request.Id),
+        return (await _context.YearOuts.AsNoTracking()
+            .SingleOrDefaultAsync(yearOut => yearOut.ID.Equals(request.Id),
             cancellationToken))!;
     }
 }

--- a/src/YaronEfrat.Yiyo.Application/Queries/GetYearOutQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/GetYearOutQuery.cs
@@ -16,6 +16,14 @@ public class GetYearOutQueryHandler : IRequestHandler<GetYearOutQuery, YearOutEn
 {
     private readonly IApplicationDbContext _context;
 
+    public IQueryable<YearOutEntity> YearOutQueryable =>
+        _context.YearOuts
+            .Include(e => e.Feelings)
+            .Include(e => e.Motto)
+            .Include(e => e.PersonalEvents)
+            .AsSplitQuery()
+            .AsNoTracking();
+
     public GetYearOutQueryHandler(IApplicationDbContext context)
     {
         _context = context;
@@ -23,7 +31,7 @@ public class GetYearOutQueryHandler : IRequestHandler<GetYearOutQuery, YearOutEn
 
     public async Task<YearOutEntity> Handle(GetYearOutQuery request, CancellationToken cancellationToken = default)
     {
-        return (await _context.YearOuts.AsNoTracking()
+        return (await YearOutQueryable
             .SingleOrDefaultAsync(yearOut => yearOut.ID.Equals(request.Id),
             cancellationToken))!;
     }

--- a/src/YaronEfrat.Yiyo.Application/Queries/PersonalEvents/GetPersonalEventListQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/PersonalEvents/GetPersonalEventListQuery.cs
@@ -26,11 +26,11 @@ public class GetPersonalEventListQueryHandler : IRequestHandler<GetPersonalEvent
     {
         if (request.Ids == null!)
         {
-            return await _context.PersonalEvents.ToArrayAsync(cancellationToken);
+            return await _context.PersonalEvents.AsNoTracking().ToArrayAsync(cancellationToken);
         }
 
         // TODO [#18]: add query validator to validate all ids are positive
-        return await _context.PersonalEvents
+        return await _context.PersonalEvents.AsNoTracking()
             .Where(pe => request.Ids.Contains(pe.ID))
             .ToArrayAsync(cancellationToken);
     }

--- a/src/YaronEfrat.Yiyo.Application/Queries/PersonalEvents/GetPersonalEventQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/PersonalEvents/GetPersonalEventQuery.cs
@@ -27,12 +27,14 @@ public class GetPersonalEventQueryHandler : IRequestHandler<GetPersonalEventQuer
     {
         if (request.Id > 0)
         {
-            return (await _context.PersonalEvents.SingleOrDefaultAsync(pe => pe.ID.Equals(request.Id),
+            return (await _context.PersonalEvents.AsNoTracking()
+                .SingleOrDefaultAsync(pe => pe.ID.Equals(request.Id),
                 cancellationToken))!;
         }
 
         return (!string.IsNullOrWhiteSpace(request.Title)
-            ? await _context.PersonalEvents.SingleOrDefaultAsync(pe => pe.Title!.Equals(request.Title),
+            ? await _context.PersonalEvents.AsNoTracking()
+                .SingleOrDefaultAsync(pe => pe.Title!.Equals(request.Title),
                 cancellationToken)
             : null)!;
     }

--- a/src/YaronEfrat.Yiyo.Application/Queries/WorldEvents/GetWorldEventListQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/WorldEvents/GetWorldEventListQuery.cs
@@ -26,11 +26,11 @@ public class GetWorldEventListQueryHandler : IRequestHandler<GetWorldEventListQu
     {
         if (request.Ids == null!)
         {
-            return await _context.WorldEvents.ToArrayAsync(cancellationToken);
+            return await _context.WorldEvents.AsNoTracking().ToArrayAsync(cancellationToken);
         }
 
         // TODO [#18]: add query validator to validate all ids are positive
-        return await _context.WorldEvents
+        return await _context.WorldEvents.AsNoTracking()
             .Where(pe => request.Ids.Contains(pe.ID))
             .ToArrayAsync(cancellationToken);
     }

--- a/src/YaronEfrat.Yiyo.Application/Queries/WorldEvents/GetWorldEventQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/WorldEvents/GetWorldEventQuery.cs
@@ -18,6 +18,9 @@ public class GetWorldEventQueryHandler : IRequestHandler<GetWorldEventQuery, Wor
 {
     private readonly IApplicationDbContext _context;
 
+    public IQueryable<WorldEventEntity> WorldEventQueryable =>
+        _context.WorldEvents.Include(e => e.Sources).AsNoTracking();
+
     public GetWorldEventQueryHandler(IApplicationDbContext context)
     {
         _context = context;
@@ -27,13 +30,13 @@ public class GetWorldEventQueryHandler : IRequestHandler<GetWorldEventQuery, Wor
     {
         if (request.Id > 0)
         {
-            return (await _context.WorldEvents.AsNoTracking()
+            return (await WorldEventQueryable
                 .SingleOrDefaultAsync(we => we.ID.Equals(request.Id),
                 cancellationToken))!;
         }
 
         return (!string.IsNullOrWhiteSpace(request.Title)
-            ? await _context.WorldEvents.AsNoTracking()
+            ? await WorldEventQueryable
                 .SingleOrDefaultAsync(we => we.Title!.Equals(request.Title), cancellationToken)
             : null)!;
     }

--- a/src/YaronEfrat.Yiyo.Application/Queries/WorldEvents/GetWorldEventQuery.cs
+++ b/src/YaronEfrat.Yiyo.Application/Queries/WorldEvents/GetWorldEventQuery.cs
@@ -27,12 +27,14 @@ public class GetWorldEventQueryHandler : IRequestHandler<GetWorldEventQuery, Wor
     {
         if (request.Id > 0)
         {
-            return (await _context.WorldEvents.SingleOrDefaultAsync(we => we.ID.Equals(request.Id),
+            return (await _context.WorldEvents.AsNoTracking()
+                .SingleOrDefaultAsync(we => we.ID.Equals(request.Id),
                 cancellationToken))!;
         }
 
         return (!string.IsNullOrWhiteSpace(request.Title)
-            ? await _context.WorldEvents.SingleOrDefaultAsync(we => we.Title!.Equals(request.Title), cancellationToken)
+            ? await _context.WorldEvents.AsNoTracking()
+                .SingleOrDefaultAsync(we => we.Title!.Equals(request.Title), cancellationToken)
             : null)!;
     }
 }

--- a/src/YaronEfrat.Yiyo.Application/Validators/CommandValidator.cs
+++ b/src/YaronEfrat.Yiyo.Application/Validators/CommandValidator.cs
@@ -26,7 +26,17 @@ public class CommandValidator<T> : ICommandValidator<T> where T : class, IDbEnti
 
     public virtual Task<bool> IsValidAddCommand(IRequest<T> request)
     {
-        return Task.FromResult(request != null! && request.GetRequestContent() is { ID: 0 });
+        bool isRequestNonNull = request != null!;
+        bool isIdNonZero = request?.GetRequestContent() is { ID: 0 };
+        if (!isRequestNonNull)
+        {
+            _logger.LogError("Request is null");
+        }
+        else if (!isIdNonZero)
+        {
+            _logger.LogError("Entity's id is non zero in an add command");
+        }
+        return Task.FromResult(isRequestNonNull && isIdNonZero);
     }
 
     protected internal async Task<bool> AreFeelingsConsistent(IList<FeelingEntity> entityFeelings)

--- a/src/YaronEfrat.Yiyo.Application/Validators/CommandValidator.cs
+++ b/src/YaronEfrat.Yiyo.Application/Validators/CommandValidator.cs
@@ -2,6 +2,8 @@
 
 using MediatR;
 
+using Microsoft.Extensions.Logging;
+
 using YaronEfrat.Yiyo.Application.Interfaces;
 using YaronEfrat.Yiyo.Application.Models;
 using YaronEfrat.Yiyo.Application.Queries;
@@ -14,10 +16,12 @@ namespace YaronEfrat.Yiyo.Application.Validators;
 public class CommandValidator<T> : ICommandValidator<T> where T : class, IDbEntity
 {
     private readonly IMediator _mediator;
+    private readonly ILogger<CommandValidator<T>> _logger;
 
-    public CommandValidator(IMediator mediator)
+    public CommandValidator(IMediator mediator, ILogger<CommandValidator<T>> logger)
     {
         _mediator = mediator;
+        _logger = logger;
     }
 
     public virtual Task<bool> IsValidAddCommand(IRequest<T> request)
@@ -32,7 +36,9 @@ public class CommandValidator<T> : ICommandValidator<T> where T : class, IDbEnti
             Ids = entityFeelings.Select(f => f.ID).ToImmutableHashSet(),
         };
         FeelingEntity[] feelingEntities = await _mediator.Send(query);
-        return feelingEntities.SequenceEqual(entityFeelings);
+        bool areFeelingsConsistent = feelingEntities.SequenceEqual(entityFeelings);
+        LogIfInconsistent(areFeelingsConsistent, nameof(FeelingEntity));
+        return areFeelingsConsistent;
     }
 
     protected internal async Task<bool> ArePersonalEventsConsistent(IList<PersonalEventEntity> entityPersonalEvents)
@@ -42,7 +48,9 @@ public class CommandValidator<T> : ICommandValidator<T> where T : class, IDbEnti
             Ids = entityPersonalEvents.Select(pe => pe.ID).ToImmutableHashSet(),
         };
         PersonalEventEntity[] personalEventEntities = await _mediator.Send(query);
-        return personalEventEntities.SequenceEqual(entityPersonalEvents);
+        bool arePersonalEventsConsistent = personalEventEntities.SequenceEqual(entityPersonalEvents);
+        LogIfInconsistent(arePersonalEventsConsistent, nameof(PersonalEventEntity));
+        return arePersonalEventsConsistent;
     }
 
     protected internal async Task<bool> AreWorldEventsConsistent(IList<WorldEventEntity> entityWorldEvents)
@@ -52,7 +60,9 @@ public class CommandValidator<T> : ICommandValidator<T> where T : class, IDbEnti
             Ids = entityWorldEvents.Select(pe => pe.ID).ToImmutableHashSet(),
         };
         WorldEventEntity[] worldEventEntities = await _mediator.Send(query);
-        return worldEventEntities.SequenceEqual(entityWorldEvents);
+        bool areWorldEventsConsistent = worldEventEntities.SequenceEqual(entityWorldEvents);
+        LogIfInconsistent(areWorldEventsConsistent, nameof(WorldEventEntity));
+        return areWorldEventsConsistent;
     }
 
     protected internal async Task<bool> IsMottoConsistent(MottoEntity motto)
@@ -63,7 +73,18 @@ public class CommandValidator<T> : ICommandValidator<T> where T : class, IDbEnti
         }
         GetMottoQuery query = new() {Id = motto.ID};
         MottoEntity dbMottoEntity = await _mediator.Send(query);
-        return dbMottoEntity != null!
-            && motto.ID == dbMottoEntity.ID && motto.Content!.Equals(dbMottoEntity.Content);
+        bool isMottoConsistent = dbMottoEntity != null!
+                                 && motto.ID == dbMottoEntity.ID
+                                 && motto.Content!.Equals(dbMottoEntity.Content);
+        LogIfInconsistent(isMottoConsistent, nameof(MottoEntity));
+        return isMottoConsistent;
+    }
+
+    private void LogIfInconsistent(bool areMembersIncosistent, string memberClassName)
+    {
+        if (!areMembersIncosistent)
+        {
+            _logger.LogError($"Request entity contained at least one inconsistent {memberClassName}");
+        }
     }
 }

--- a/src/YaronEfrat.Yiyo.Application/Validators/FeelingCommandValidator.cs
+++ b/src/YaronEfrat.Yiyo.Application/Validators/FeelingCommandValidator.cs
@@ -1,12 +1,14 @@
 ﻿using MediatR;
 
+using Microsoft.Extensions.Logging;
+
 using YaronEfrat.Yiyo.Application.Models;
 
 namespace YaronEfrat.Yiyo.Application.Validators;
 
 public class FeelingCommandValidator : CommandValidator<FeelingEntity>
 {
-    public FeelingCommandValidator(IMediator mediator) : base(mediator)
+    public FeelingCommandValidator(IMediator mediator, ILogger<FeelingCommandValidator> logger) : base(mediator, logger)
     { }
 
     public override async Task<bool> IsValidAddCommand(IRequest<FeelingEntity> request)

--- a/src/YaronEfrat.Yiyo.Application/Validators/YearInCommandValidator.cs
+++ b/src/YaronEfrat.Yiyo.Application/Validators/YearInCommandValidator.cs
@@ -1,12 +1,14 @@
 ﻿using MediatR;
 
+using Microsoft.Extensions.Logging;
+
 using YaronEfrat.Yiyo.Application.Models;
 
 namespace YaronEfrat.Yiyo.Application.Validators;
 
 public class YearInCommandValidator : CommandValidator<YearInEntity>
 {
-    public YearInCommandValidator(IMediator mediator) : base(mediator)
+    public YearInCommandValidator(IMediator mediator, ILogger<YearInCommandValidator> logger) : base(mediator, logger)
     { }
 
     public override async Task<bool> IsValidAddCommand(IRequest<YearInEntity> request)

--- a/src/YaronEfrat.Yiyo.Application/Validators/YearOutCommandValidator.cs
+++ b/src/YaronEfrat.Yiyo.Application/Validators/YearOutCommandValidator.cs
@@ -1,12 +1,14 @@
 ﻿using MediatR;
 
+using Microsoft.Extensions.Logging;
+
 using YaronEfrat.Yiyo.Application.Models;
 
 namespace YaronEfrat.Yiyo.Application.Validators;
 
 public class YearOutCommandValidator : CommandValidator<YearOutEntity>
 {
-    public YearOutCommandValidator(IMediator mediator) : base(mediator)
+    public YearOutCommandValidator(IMediator mediator, ILogger<YearOutCommandValidator> logger) : base(mediator, logger)
     { }
 
     public override async Task<bool> IsValidAddCommand(IRequest<YearOutEntity> request)

--- a/src/YaronEfrat.Yiyo.Application/YaronEfrat.Yiyo.Application.csproj
+++ b/src/YaronEfrat.Yiyo.Application/YaronEfrat.Yiyo.Application.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="MediatR" Version="12.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/YaronEfrat.Yiyo.Persistence/ApplicationDbContext.cs
+++ b/src/YaronEfrat.Yiyo.Persistence/ApplicationDbContext.cs
@@ -20,4 +20,15 @@ public class ApplicationDbContext : DbContext, IApplicationDbContext
     public DbSet<YearOutEntity> YearOuts { get; set; } = default!;
 
     public ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : base(options) {}
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.Entity<FeelingEntity>()
+            .HasMany(e => e.PersonalEvents)
+            .WithMany();
+
+        modelBuilder.Entity<WorldEventEntity>()
+            .HasMany(e => e.Sources)
+            .WithMany();
+    }
 }

--- a/src/YaronEfrat.Yiyo.WebApi/Program.cs
+++ b/src/YaronEfrat.Yiyo.WebApi/Program.cs
@@ -16,6 +16,8 @@ builder.Services.AddPersistenceLayerDependencyInjection(builder.Configuration);
 
 builder.Services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblyContaining<YearInController>());
 
+builder.Services.AddLogging();
+
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Commands/Feelings/AddFeelingCommandHandlerTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Commands/Feelings/AddFeelingCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 using Moq;
 
@@ -34,7 +35,8 @@ internal class AddFeelingCommandHandlerTests
         _addFeelingCommandHandler = new AddFeelingCommandHandler(_dbContextMock.Object,
             new FeelingDbEntityToDomainEntityMapper(new PersonalEventDbEntityToDomainEntityMapper()),
             new FeelingDomainEntityToDbEntityMapper(new PersonalEventDomainEntityToDbEntityMapper()),
-            new CommandValidator<FeelingEntity>(null));
+            new CommandValidator<FeelingEntity>(null!,
+                new Mock<ILogger<CommandValidator<FeelingEntity>>>().Object));
     }
 
     private void InitializeDbSet(IList<FeelingEntity> feelingEntities)
@@ -42,6 +44,8 @@ internal class AddFeelingCommandHandlerTests
         _dbSetMock = TestFixtures.DbSetMock(feelingEntities);
         _dbContextMock.Setup(mock => mock.Feelings)
             .Returns(_dbSetMock.Object);
+        _dbContextMock.Setup(mock => mock.PersonalEvents)
+            .Returns(TestFixtures.DbSetMock(DbEntitiesTestCases.PersonalEvents).Object);
     }
 
     [TestCaseSource(typeof(DbEntitiesTestCases), nameof(DbEntitiesTestCases.Feelings))]

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Commands/Mottos/AddMottoCommandHandlerTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Commands/Mottos/AddMottoCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 using Moq;
 
@@ -33,7 +34,8 @@ internal class AddMottoCommandHandlerTests
         _addMottoCommandHandler = new AddMottoCommandHandler(_dbContextMock.Object,
             new MottoDbEntityToDomainEntityMapper(),
             new MottoDomainEntityToDbEntityMapper(),
-            new CommandValidator<MottoEntity>(null!));
+            new CommandValidator<MottoEntity>(null!,
+                new Mock<ILogger<CommandValidator<MottoEntity>>>().Object));
     }
 
     private void InitializeDbSet(IList<MottoEntity> mottoEntities)

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Commands/PersonalEvents/AddPersonalEventCommandHandlerTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Commands/PersonalEvents/AddPersonalEventCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 using Moq;
 
@@ -33,7 +34,8 @@ internal class AddPersonalEventCommandHandlerTests
         _addPersonalEventCommandHandler = new AddPersonalEventCommandHandler(_dbContextMock.Object,
             new PersonalEventDbEntityToDomainEntityMapper(),
             new PersonalEventDomainEntityToDbEntityMapper(),
-            new CommandValidator<PersonalEventEntity>(null!));
+            new CommandValidator<PersonalEventEntity>(null!,
+                new Mock<ILogger<CommandValidator<PersonalEventEntity>>>().Object));
     }
 
     private void InitializeDbSet(IList<PersonalEventEntity> personalEventEntities)

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Commands/Sources/AddSourceCommandHandlerTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Commands/Sources/AddSourceCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 using Moq;
 
@@ -28,7 +29,8 @@ internal class AddSourceCommandHandlerTests
         InitializeDbSet(new List<SourceEntity>());
 
         _addSourceCommandHandler = new AddSourceCommandHandler(_dbContextMock.Object,
-            new CommandValidator<SourceEntity>(null!));
+            new CommandValidator<SourceEntity>(null!,
+                new Mock<ILogger<CommandValidator<SourceEntity>>>().Object));
     }
 
     private void InitializeDbSet(IList<SourceEntity> sourceEntities)

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Commands/WorldEvents/AddWorldEventCommandHandlerTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Commands/WorldEvents/AddWorldEventCommandHandlerTests.cs
@@ -3,6 +3,7 @@
 using MediatR;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 using Moq;
 
@@ -43,7 +44,8 @@ internal class AddWorldEventCommandHandlerTests
             .Returns(_sourcesMock.Object);
 
         _addSourceCommandHandler = new AddSourceCommandHandler(_dbContextMock.Object,
-            new CommandValidator<SourceEntity>(null!));
+            new CommandValidator<SourceEntity>(null!,
+                new Mock<ILogger<CommandValidator<SourceEntity>>>().Object));
         _updateSourceCommandHandler = new UpdateSourceCommandHandler(_dbContextMock.Object);
 
         _mediatorMock = new Mock<IMediator>();
@@ -58,7 +60,8 @@ internal class AddWorldEventCommandHandlerTests
             new WorldEventDbEntityToDomainEntityMapper(),
             new WorldEventDomainEntityToDbEntityMapper(),
             _mediatorMock.Object,
-            new CommandValidator<WorldEventEntity>(null!));
+            new CommandValidator<WorldEventEntity>(null!,
+                new Mock<ILogger<CommandValidator<WorldEventEntity>>>().Object));
     }
 
     private void InitializeDbSet(IList<WorldEventEntity> worldEventEntities)

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Commands/YearIns/AddYearInCommandHandlerTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Commands/YearIns/AddYearInCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 using Moq;
 
@@ -48,7 +49,8 @@ internal class AddYearInCommandHandlerTests
             new WorldEventDomainEntityToDbEntityMapper());
         _addYearInCommandHandler = new AddYearInCommandHandler(_dbContextMock.Object,
             dbToDomainMapper, domainToDbMapper,
-            new CommandValidator<YearInEntity>(null!));
+            new CommandValidator<YearInEntity>(null!,
+                new Mock<ILogger<CommandValidator<YearInEntity>>>().Object));
     }
 
     private void InitializeDbSet(IList<YearInEntity> yearInEntities)
@@ -56,6 +58,14 @@ internal class AddYearInCommandHandlerTests
         _dbSetMock = TestFixtures.DbSetMock(yearInEntities);
         _dbContextMock.Setup(mock => mock.YearIns)
             .Returns(_dbSetMock.Object);
+        _dbContextMock.Setup(mock => mock.Feelings)
+            .Returns(TestFixtures.DbSetMock(DbEntitiesTestCases.Feelings).Object);
+        _dbContextMock.Setup(mock => mock.Mottos)
+            .Returns(TestFixtures.DbSetMock(DbEntitiesTestCases.Mottos).Object);
+        _dbContextMock.Setup(mock => mock.PersonalEvents)
+            .Returns(TestFixtures.DbSetMock(DbEntitiesTestCases.PersonalEvents).Object);
+        _dbContextMock.Setup(mock => mock.WorldEvents)
+            .Returns(TestFixtures.DbSetMock(DbEntitiesTestCases.WorldEvents).Object);
     }
 
     [TestCaseSource(typeof(DbEntitiesTestCases), nameof(DbEntitiesTestCases.YearIns))]

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Commands/YearOuts/AddYearOutCommandHandlerTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Commands/YearOuts/AddYearOutCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 using Moq;
 
@@ -45,7 +46,8 @@ internal class AddYearOutCommandHandlerTests
             personalEventDomainToDbMapper);
         _addYearOutCommandHandler = new AddYearOutCommandHandler(_dbContextMock.Object,
             dbToDomainMapper, domainToDbMapper,
-            new CommandValidator<YearOutEntity>(null!));
+            new CommandValidator<YearOutEntity>(null!,
+                new Mock<ILogger<CommandValidator<YearOutEntity>>>().Object));
     }
 
     private void InitializeDbSet(IList<YearOutEntity> yearOutEntities)
@@ -53,6 +55,12 @@ internal class AddYearOutCommandHandlerTests
         _dbSetMock = TestFixtures.DbSetMock(yearOutEntities);
         _dbContextMock.Setup(mock => mock.YearOuts)
             .Returns(_dbSetMock.Object);
+        _dbContextMock.Setup(mock => mock.Feelings)
+            .Returns(TestFixtures.DbSetMock(DbEntitiesTestCases.Feelings).Object);
+        _dbContextMock.Setup(mock => mock.Mottos)
+            .Returns(TestFixtures.DbSetMock(DbEntitiesTestCases.Mottos).Object);
+        _dbContextMock.Setup(mock => mock.PersonalEvents)
+            .Returns(TestFixtures.DbSetMock(DbEntitiesTestCases.PersonalEvents).Object);
     }
 
     [TestCaseSource(typeof(DbEntitiesTestCases), nameof(DbEntitiesTestCases.YearOuts))]

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Validators/FeelingCommandValidatorTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Validators/FeelingCommandValidatorTests.cs
@@ -2,6 +2,7 @@
 
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 using Moq;
 
@@ -40,7 +41,8 @@ internal class FeelingCommandValidatorTests
             .Returns(async (GetPersonalEventListQuery q, CancellationToken token) =>
                 await _getPersonalEventListQueryHandler.Handle(q, token));
 
-        _validator = new FeelingCommandValidator(_mediatorMock.Object);
+        _validator = new FeelingCommandValidator(_mediatorMock.Object,
+            new Mock<ILogger<FeelingCommandValidator>>().Object);
     }
 
     [TestCaseSource(typeof(DbEntitiesTestCases), nameof(DbEntitiesTestCases.Feelings))]

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Validators/YearInCommandValidatorTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Validators/YearInCommandValidatorTests.cs
@@ -2,6 +2,8 @@
 
 using MediatR;
 
+using Microsoft.Extensions.Logging;
+
 using Moq;
 
 using NUnit.Framework;
@@ -62,7 +64,8 @@ internal class YearInCommandValidatorTests
             .Returns(async (GetWorldEventListQuery q, CancellationToken token) =>
                 await _getWorldEventListQueryHandler.Handle(q, token));
 
-        _validator = new YearInCommandValidator(_mediatorMock.Object);
+        _validator = new YearInCommandValidator(_mediatorMock.Object,
+            new Mock<ILogger<YearInCommandValidator>>().Object);
     }
 
     [TestCaseSource(typeof(DbEntitiesTestCases), nameof(DbEntitiesTestCases.YearIns))]

--- a/tests/YaronEfrat.Yiyo.Application.UnitTests/Validators/YearOutCommandValidatorTests.cs
+++ b/tests/YaronEfrat.Yiyo.Application.UnitTests/Validators/YearOutCommandValidatorTests.cs
@@ -2,6 +2,8 @@
 
 using MediatR;
 
+using Microsoft.Extensions.Logging;
+
 using Moq;
 
 using NUnit.Framework;
@@ -54,7 +56,8 @@ internal class YearOutCommandValidatorTests
             .Returns(async (GetPersonalEventListQuery q, CancellationToken token) =>
                 await _getPersonalEventListQueryHandler.Handle(q, token));
 
-        _validator = new YearOutCommandValidator(_mediatorMock.Object);
+        _validator = new YearOutCommandValidator(_mediatorMock.Object,
+            new Mock<ILogger<YearOutCommandValidator>>().Object);
     }
 
     [TestCaseSource(typeof(DbEntitiesTestCases), nameof(DbEntitiesTestCases.YearOuts))]


### PR DESCRIPTION
In this PR, we fix the issues with adding entities that have relationships with existing entities.
On the way, we do some logging in the validator and some refactoring.
We also make sure to include the relations for queries that retrieve only one entity.

+semver: patch
